### PR TITLE
Add tool index and generation workflow

### DIFF
--- a/.github/workflows/generate_tools.yml
+++ b/.github/workflows/generate_tools.yml
@@ -1,0 +1,30 @@
+name: Generate tools.json
+
+on:
+  push:
+    branches: [ main, work ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22
+      - name: Generate tools.json
+        run: node generate-tools.js
+      - name: Commit tools.json
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add tools.json
+          if git diff --cached --quiet; then
+            echo "No changes"
+          else
+            git commit -m "Update tools.json"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/generate-tools.js
+++ b/generate-tools.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const toolsDir = path.join(__dirname, 'tools');
+const toolFiles = fs.readdirSync(toolsDir).filter(f => f.endsWith('.html'));
+
+const tools = toolFiles.map(file => {
+  const fullPath = path.join(toolsDir, file);
+  const html = fs.readFileSync(fullPath, 'utf8');
+  const titleMatch = html.match(/<title>([^<]*)<\/title>/i);
+  const title = titleMatch ? titleMatch[1].trim() : path.parse(file).name;
+  const descMatch = html.match(/<meta[^>]+name=['"]description['"][^>]+content=['"]([^'"]*)['"][^>]*>/i);
+  const description = descMatch ? descMatch[1].trim() : '';
+  const keyMatch = html.match(/<meta[^>]+name=['"]keywords['"][^>]+content=['"]([^'"]*)['"][^>]*>/i);
+  const keywords = keyMatch ? keyMatch[1].split(',').map(k => k.trim()).filter(Boolean) : [];
+  return {
+    file: `tools/${file}`,
+    title,
+    description,
+    keywords
+  };
+});
+
+fs.writeFileSync(path.join(__dirname, 'tools.json'), JSON.stringify(tools, null, 2));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tool Gallery</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/@emotion/react@latest/dist/emotion-react.umd.min.js"></script>
+  <script crossorigin src="https://unpkg.com/@emotion/styled@latest/dist/emotion-styled.umd.min.js"></script>
+  <script crossorigin src="https://unpkg.com/@mui/material@latest/umd/material-ui.production.min.js"></script>
+</head>
+<body style="margin:0;">
+  <div id="root"></div>
+  <script src="index.js"></script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,58 @@
+const { useState, useEffect } = React;
+const { Container, Box, Grid, TextField, Card, CardContent, Typography } = MaterialUI;
+
+function App() {
+  const [tools, setTools] = useState([]);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    fetch('tools.json')
+      .then(res => res.json())
+      .then(setTools);
+  }, []);
+
+  const filtered = tools.filter(t => {
+    const lower = query.toLowerCase();
+    return (
+      t.title.toLowerCase().includes(lower) ||
+      t.description.toLowerCase().includes(lower) ||
+      (t.keywords || []).some(k => k.toLowerCase().includes(lower))
+    );
+  });
+
+  return (
+    React.createElement(Container, { sx: { py: 4 } },
+      React.createElement(Box, { sx: { mb: 2 } },
+        React.createElement(TextField, {
+          fullWidth: true,
+          label: 'Search tools',
+          variant: 'outlined',
+          value: query,
+          onChange: e => setQuery(e.target.value)
+        })
+      ),
+      React.createElement(Grid, { container: true, spacing: 2 },
+        filtered.map(tool => (
+          React.createElement(Grid, { item: true, xs: 12, sm: 6, md: 4, key: tool.file },
+            React.createElement(Card, null,
+              React.createElement('iframe', {
+                src: tool.file,
+                style: { width: '100%', height: '200px', border: 0 }
+              }),
+              React.createElement(CardContent, null,
+                React.createElement(Typography, { variant: 'h6' }, tool.title),
+                React.createElement(Typography, { variant: 'body2', sx: { mb: 1 } }, tool.description),
+                tool.keywords && tool.keywords.length > 0 &&
+                  React.createElement(Typography, { variant: 'caption', color: 'text.secondary' },
+                    'Keywords: ' + tool.keywords.join(', ')
+                  )
+              )
+            )
+          )
+        ))
+      )
+    )
+  );
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "uptooled",
+  "version": "1.0.0",
+  "description": "Tools gallery",
+  "main": "generate-tools.js",
+  "scripts": {
+    "generate": "node generate-tools.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/tools.json
+++ b/tools.json
@@ -1,0 +1,8 @@
+[
+  {
+    "file": "tools/Calendar Timeline Visualizer.html",
+    "title": "Calendar Timeline Visualizer",
+    "description": "",
+    "keywords": []
+  }
+]


### PR DESCRIPTION
## Summary
- generate `tools.json` using Node
- serve tools via React + MUI landing page
- set up GitHub action to rebuild `tools.json` on each push
- basic project metadata and ignore rule
- **use Node 22** and include `keywords` in tool metadata

## Testing
- `node generate-tools.js`


------
https://chatgpt.com/codex/tasks/task_e_68447c460790832b9c4d301743845d35