### PR TITLE
Improve tool viewer UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,22 +3,63 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Browse handy utilities and preview them inline.">
+  <meta name="keywords" content="tools, gallery, productivity">
   <title>Tool Gallery</title>
   <link rel="preload" href="tools.json" as="fetch" crossorigin>
   <link rel="preload" href="index.js" as="script">
   <link rel="stylesheet" href="https://cdn.muicss.com/mui-latest/css/mui.min.css">
   <style>
-    body { margin: 0; }
-    .tool-frame { width: 100%; height: 200px; border: 0; }
-    .tool-card { margin-bottom: 16px; }
+    body {
+      margin: 0;
+      display: flex;
+      height: 100vh;
+      overflow: hidden;
+    }
+    #sidebar {
+      width: 250px;
+      border-right: 1px solid #ddd;
+      overflow-y: auto;
+      padding: 1rem;
+    }
+    #main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+    #tool-frame {
+      flex: 1;
+      border: 0;
+      width: 100%;
+    }
+    #tool-info {
+      padding: 1rem;
+      border-top: 1px solid #ddd;
+    }
+    @media (max-width: 600px) {
+      body { flex-direction: column; }
+      #sidebar {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #ddd;
+      }
+    }
   </style>
 </head>
 <body>
-  <div class="mui-container">
+  <div id="sidebar">
     <div class="mui-textfield">
       <input type="text" id="search" placeholder="Search tools">
     </div>
-    <div id="tool-container" class="mui-row"></div>
+    <ul id="tool-list" class="mui-list--unstyled"></ul>
+  </div>
+  <div id="main">
+    <iframe id="tool-frame"></iframe>
+    <div id="tool-info">
+      <h3 id="tool-title"></h3>
+      <p id="tool-description"></p>
+      <small id="tool-keywords"></small>
+    </div>
   </div>
   <script src="index.js" defer></script>
 

--- a/index.js
+++ b/index.js
@@ -1,52 +1,67 @@
-// Minimal search and render for tools
+// Render sidebar list and iframe viewer for tools
 async function init() {
   const res = await fetch('tools.json');
   const tools = await res.json();
-  const container = document.getElementById('tool-container');
-  const search = document.getElementById('search');
+
+  const searchEl = document.getElementById('search');
+  const listEl = document.getElementById('tool-list');
+  const frameEl = document.getElementById('tool-frame');
+  const titleEl = document.getElementById('tool-title');
+  const descEl = document.getElementById('tool-description');
+  const keysEl = document.getElementById('tool-keywords');
 
   function matches(tool, q) {
     q = q.toLowerCase();
-    return tool.title.toLowerCase().includes(q) ||
-           tool.description.toLowerCase().includes(q) ||
-           (tool.keywords || []).some(k => k.toLowerCase().includes(q));
+    return (
+      tool.title.toLowerCase().includes(q) ||
+      tool.description.toLowerCase().includes(q) ||
+      (tool.keywords || []).some(k => k.toLowerCase().includes(q))
+    );
   }
 
-  function render(list) {
-    container.innerHTML = '';
+  function renderList(list) {
+    listEl.innerHTML = '';
     list.forEach(tool => {
-      const col = document.createElement('div');
-      col.className = 'mui-col-md-4 mui-col-sm-6 mui-col-xs-12';
-      const panel = document.createElement('div');
-      panel.className = 'mui-panel tool-card';
-      const iframe = document.createElement('iframe');
-      iframe.src = tool.file;
-      iframe.className = 'tool-frame';
-      const title = document.createElement('h3');
-      title.textContent = tool.title;
-      const desc = document.createElement('p');
-      desc.textContent = tool.description;
-      panel.appendChild(iframe);
-      panel.appendChild(title);
-      panel.appendChild(desc);
-      if (tool.keywords && tool.keywords.length) {
-        const keys = document.createElement('small');
-        keys.textContent = 'Keywords: ' + tool.keywords.join(', ');
-        panel.appendChild(keys);
-      }
-      col.appendChild(panel);
-      container.appendChild(col);
+      const li = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = '#';
+      link.textContent = tool.title;
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        selectTool(tool);
+      });
+      li.appendChild(link);
+      listEl.appendChild(li);
     });
   }
 
-  function filter() {
-    const q = search.value.trim();
-    render(q ? tools.filter(t => matches(t, q)) : tools);
+  function selectTool(tool) {
+    frameEl.src = tool.file;
+    titleEl.textContent = tool.title;
+    descEl.textContent = tool.description || '';
+    keysEl.textContent =
+      tool.keywords && tool.keywords.length
+        ? 'Keywords: ' + tool.keywords.join(', ')
+        : '';
   }
 
-  search.addEventListener('input', filter);
-  render(tools);
+  function filter() {
+    const q = searchEl.value.trim();
+    const filtered = q ? tools.filter(t => matches(t, q)) : tools;
+    renderList(filtered);
+    if (filtered.length) {
+      selectTool(filtered[0]);
+    } else {
+      frameEl.src = '';
+      titleEl.textContent = 'No tool found';
+      descEl.textContent = '';
+      keysEl.textContent = '';
+    }
+  }
+
+  searchEl.addEventListener('input', filter);
+  renderList(tools);
+  if (tools.length) selectTool(tools[0]);
 }
 
 document.addEventListener('DOMContentLoaded', init);
-

--- a/tools.json
+++ b/tools.json
@@ -2,7 +2,16 @@
   {
     "file": "tools/Calendar Timeline Visualizer.html",
     "title": "Calendar Timeline Visualizer",
-    "description": "",
-    "keywords": []
+    "description": "A free, interactive tool to create beautiful, color-coded project timelines. Input your project phases, set durations, and instantly generate a shareable visual calendar. Export to PNG or SVG.",
+    "keywords": [
+      "timeline generator",
+      "project timeline",
+      "gantt chart",
+      "project management",
+      "roadmap planner",
+      "visual calendar",
+      "project schedule",
+      "free tool"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- restyle `index.html` to use a sidebar layout
- show tool description and keywords
- display selected tool in an iframe
- update `index.js` logic for sidebar viewer
- regenerate `tools.json`

## Testing
- `node generate-tools.js`
- `npm run generate`

------
https://chatgpt.com/codex/tasks/task_e_684484942454832b975098439e841118