### PR TITLE
Implement grid view when no tool selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,28 @@
       display: flex;
       flex-direction: column;
     }
+    #grid-view {
+      display: grid;
+      gap: 1rem;
+      padding: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+    @media (min-width: 1000px) {
+      #grid-view {
+        grid-template-columns: repeat(3, 1fr);
+      }
+    }
+    .tool-card {
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      padding: 1rem;
+    }
+    .card-frame {
+      width: 100%;
+      height: 220px;
+      border: 0;
+      margin-bottom: 0.5rem;
+    }
     #tool-frame {
       flex: 1;
       border: 0;
@@ -54,11 +76,14 @@
     <ul id="tool-list" class="mui-list--unstyled"></ul>
   </div>
   <div id="main">
-    <iframe id="tool-frame"></iframe>
-    <div id="tool-info">
-      <h3 id="tool-title"></h3>
-      <p id="tool-description"></p>
-      <small id="tool-keywords"></small>
+    <div id="grid-view"></div>
+    <div id="viewer" style="display:none; flex:1; flex-direction:column;">
+      <iframe id="tool-frame"></iframe>
+      <div id="tool-info">
+        <h3 id="tool-title"></h3>
+        <p id="tool-description"></p>
+        <small id="tool-keywords"></small>
+      </div>
     </div>
   </div>
   <script src="index.js" defer></script>

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ async function init() {
 
   const searchEl = document.getElementById('search');
   const listEl = document.getElementById('tool-list');
+  const gridEl = document.getElementById('grid-view');
+  const viewerEl = document.getElementById('viewer');
   const frameEl = document.getElementById('tool-frame');
   const titleEl = document.getElementById('tool-title');
   const descEl = document.getElementById('tool-description');
@@ -35,6 +37,36 @@ async function init() {
     });
   }
 
+  function renderGrid(list) {
+    gridEl.innerHTML = '';
+    list.forEach(tool => {
+      const card = document.createElement('div');
+      card.className = 'tool-card';
+      const iframe = document.createElement('iframe');
+      iframe.className = 'card-frame';
+      iframe.src = tool.file;
+      const title = document.createElement('h3');
+      title.textContent = tool.title;
+      const desc = document.createElement('p');
+      desc.textContent = tool.description || '';
+      card.appendChild(iframe);
+      card.appendChild(title);
+      card.appendChild(desc);
+      card.addEventListener('click', () => selectTool(tool));
+      gridEl.appendChild(card);
+    });
+  }
+
+  function showGrid() {
+    viewerEl.style.display = 'none';
+    gridEl.style.display = 'grid';
+  }
+
+  function showViewer() {
+    gridEl.style.display = 'none';
+    viewerEl.style.display = 'flex';
+  }
+
   function selectTool(tool) {
     frameEl.src = tool.file;
     titleEl.textContent = tool.title;
@@ -43,6 +75,7 @@ async function init() {
       tool.keywords && tool.keywords.length
         ? 'Keywords: ' + tool.keywords.join(', ')
         : '';
+    showViewer();
   }
 
   function filter() {
@@ -50,18 +83,18 @@ async function init() {
     const filtered = q ? tools.filter(t => matches(t, q)) : tools;
     renderList(filtered);
     if (filtered.length) {
-      selectTool(filtered[0]);
+      renderGrid(filtered);
+      showGrid();
     } else {
-      frameEl.src = '';
-      titleEl.textContent = 'No tool found';
-      descEl.textContent = '';
-      keysEl.textContent = '';
+      gridEl.innerHTML = '<p>No tool found</p>';
+      showGrid();
     }
   }
 
   searchEl.addEventListener('input', filter);
   renderList(tools);
-  if (tools.length) selectTool(tools[0]);
+  renderGrid(tools);
+  showGrid();
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/tools.json
+++ b/tools.json
@@ -13,5 +13,22 @@
       "project schedule",
       "free tool"
     ]
+  },
+  {
+    "file": "tools/Image Resizer and Cropper.html",
+    "title": "Free Image Resizer & Cropper - Online Tool",
+    "description": "A free online tool to resize, crop, and edit images for any purpose. Perfect for creating favicons, app icons (Chrome extensions, web apps), and social media assets. Features zoom, pan, and custom background colors.",
+    "keywords": [
+      "image resizer",
+      "image cropper",
+      "icon generator",
+      "favicon creator",
+      "resize image online",
+      "crop image",
+      "png resizer",
+      "jpeg resizer",
+      "chrome extension icons",
+      "web app icons"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- show wide-card grid when nothing is selected
- update viewer logic to switch between grid and single tool
- regenerate tool metadata

## Testing
- `npm run generate`

------
https://chatgpt.com/codex/tasks/task_e_684488764754832bae20c99d74a28c81