### PR TITLE
Add background image and download to poster tool

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -50,7 +50,7 @@
   },
   {
     "file": "tools/Poster Creator.html",
-    "title": "Poster Creator",
+    "title": "Quick Block Text Poster",
     "description": "Create stunning posters with a powerful online tool. Customize text, fonts, colors, and layouts to design your perfect poster.",
     "keywords": [
       "poster creator",

--- a/tools/Poster Creator.html
+++ b/tools/Poster Creator.html
@@ -11,7 +11,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400;1,700&family=Lobster&family=Lato:ital,wght@0,400;0,700;1,400;1,700&family=Montserrat:ital,wght@0,400;0,700;1,400;1,700&family=Oswald:wght@400;700&family=Merriweather:ital,wght@0,400;0,700;1,400;1,700&family=Lora:ital,wght@0,400;0,700;1,400;1,700&family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&family=Raleway:ital,wght@0,400;0,700;1,400;1,700&family=Alfa+Slab+One&family=Bebas+Neue&family=Pacifico&family=Righteous&family=Indie+Flower&family=Patrick+Hand&family=Dancing+Script:wght@400;700&family=Caveat:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Lobster&family=Lato:wght@400;700&family=Montserrat:wght@400;700&family=Oswald:wght@400;700&family=Merriweather:wght@400;700&family=Lora:wght@400;700&family=Playfair+Display:wght@400;700&family=Raleway:wght@400;700&family=Alfa+Slab+One&family=Bebas+Neue&family=Pacifico&family=Righteous&family=Indie+Flower&family=Patrick+Hand&family=Dancing+Script:wght@400;700&family=Caveat:wght@400;700&family=Julius+Sans+One&family=Great+Vibes&family=Allura&family=Open+Sans:wght@400;700&family=Alegreya:wght@400;700&family=League+Gothic&family=Bangers&family=Alata&family=Amatic+SC&family=Courgette&family=Playlist+Script&family=Anton&family=Cantora+One&family=Cooper+Hewitt&family=Noto+Sans:wght@400;700&family=Source+Sans+3:wght@400;700&family=Sinkin+Sans&family=Comic+Neue:wght@400;700&family=Barriecito&family=Reef&family=Fredoka+One&family=Vidaloka&family=Sacramento&family=Jonathan+Script&family=Brightwall&family=League+Spartan:wght@400;700&family=Yearbook+Solid&family=College&family=Source+Serif+Pro:wght@400;700&family=Muller:wght@400;700&display=swap" rel="stylesheet">
     <style>
         body { font-family: 'Roboto', sans-serif; overflow: hidden; }
         #loading-overlay { position: fixed; inset: 0; background-color: rgba(255, 255, 255, 0.8); z-index: 9999; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(4px); }
@@ -91,7 +91,9 @@ HAVE FUN
             </div>
             <div class="mb-4">
                 <label for="bg-color" class="block text-sm font-medium text-gray-700 mb-1">Background Color</label>
-                <input type="color" id="bg-color" value="#00008B" class="w-full h-10 p-1 border border-gray-300 rounded-md">
+                <input type="color" id="bg-color" value="#00008B" class="w-full h-10 p-1 border border-gray-300 rounded-md mb-1">
+                <label for="bg-alpha" class="block text-sm font-medium text-gray-700 mb-1">Background Opacity</label>
+                <input type="range" id="bg-alpha" min="0" max="1" step="0.05" value="1" class="w-full">
             </div>
             <div class="mb-4">
                 <label for="bg-image" class="block text-sm font-medium text-gray-700 mb-1">Background Image</label>
@@ -100,14 +102,18 @@ HAVE FUN
             <div class="p-4 border rounded-md mb-4 bg-gray-50">
                 <h2 class="text-lg font-semibold mb-2 text-gray-700">Primary Font</h2>
                 <select id="primary-font" class="w-full p-2 border border-gray-300 rounded-md mb-2"></select>
-                <input type="color" id="primary-color" value="#FFFFFF" class="w-full h-10 p-1 border border-gray-300 rounded-md mb-2">
-                <div class="flex items-center space-x-4"><label class="flex items-center"><input type="checkbox" id="primary-bold" class="rounded text-indigo-600"><span class="ml-2 text-sm">Bold</span></label><label class="flex items-center"><input type="checkbox" id="primary-italic" class="rounded text-indigo-600"><span class="ml-2 text-sm">Italic</span></label></div>
+                <input type="color" id="primary-color" value="#FFFFFF" class="w-full h-10 p-1 border border-gray-300 rounded-md mb-1">
+                <label for="primary-alpha" class="block text-sm font-medium text-gray-700 mb-1">Opacity</label>
+                <input type="range" id="primary-alpha" min="0" max="1" step="0.05" value="1" class="w-full mb-2">
+                <div class="flex flex-wrap items-center gap-4"><label class="flex items-center"><input type="checkbox" id="primary-bold" class="rounded text-indigo-600"><span class="ml-2 text-sm">Bold</span></label><label class="flex items-center"><input type="checkbox" id="primary-italic" class="rounded text-indigo-600"><span class="ml-2 text-sm">Italic</span></label><label class="flex items-center"><input type="checkbox" id="primary-strike" class="rounded text-indigo-600"><span class="ml-2 text-sm">Strike</span></label><label class="flex items-center"><input type="checkbox" id="primary-shadow" class="rounded text-indigo-600"><span class="ml-2 text-sm">Shadow</span></label></div>
             </div>
             <div class="p-4 border rounded-md bg-gray-50">
                 <h2 class="text-lg font-semibold mb-2 text-gray-700">Call-to-Action Font (*)</h2>
                 <select id="secondary-font" class="w-full p-2 border border-gray-300 rounded-md mb-2"></select>
-                <input type="color" id="secondary-color" value="#ADD8E6" class="w-full h-10 p-1 border border-gray-300 rounded-md mb-2">
-                 <div class="flex items-center space-x-4"><label class="flex items-center"><input type="checkbox" id="secondary-bold" class="rounded text-indigo-600"><span class="ml-2 text-sm">Bold</span></label><label class="flex items-center"><input type="checkbox" id="secondary-italic" class="rounded text-indigo-600"><span class="ml-2 text-sm">Italic</span></label></div>
+                <input type="color" id="secondary-color" value="#ADD8E6" class="w-full h-10 p-1 border border-gray-300 rounded-md mb-1">
+                <label for="secondary-alpha" class="block text-sm font-medium text-gray-700 mb-1">Opacity</label>
+                <input type="range" id="secondary-alpha" min="0" max="1" step="0.05" value="1" class="w-full mb-2">
+                 <div class="flex flex-wrap items-center gap-4"><label class="flex items-center"><input type="checkbox" id="secondary-bold" class="rounded text-indigo-600"><span class="ml-2 text-sm">Bold</span></label><label class="flex items-center"><input type="checkbox" id="secondary-italic" class="rounded text-indigo-600"><span class="ml-2 text-sm">Italic</span></label><label class="flex items-center"><input type="checkbox" id="secondary-strike" class="rounded text-indigo-600"><span class="ml-2 text-sm">Strike</span></label><label class="flex items-center"><input type="checkbox" id="secondary-shadow" class="rounded text-indigo-600"><span class="ml-2 text-sm">Shadow</span></label></div>
             </div>
         </div>
     </div>
@@ -132,11 +138,15 @@ HAVE FUN
                         </div>
                         <div class="mb-2">
                             <label for="editor-color" class="block text-sm font-medium text-gray-700 mb-1">Color</label>
-                            <input id="editor-color" type="color" class="w-full h-8 p-0 border border-gray-300 rounded-md">
+                            <input id="editor-color" type="color" class="w-full h-8 p-0 border border-gray-300 rounded-md mb-1">
+                            <label for="editor-alpha" class="block text-sm font-medium text-gray-700 mb-1">Opacity</label>
+                            <input id="editor-alpha" type="range" min="0" max="1" step="0.05" value="1" class="w-full">
                         </div>
-                        <div class="flex items-center space-x-4 mb-4">
+                        <div class="flex flex-wrap items-center gap-4 mb-4">
                             <label class="flex items-center"><input type="checkbox" id="editor-bold" class="rounded text-indigo-600"><span class="ml-2 text-sm">Bold</span></label>
                             <label class="flex items-center"><input type="checkbox" id="editor-italic" class="rounded text-indigo-600"><span class="ml-2 text-sm">Italic</span></label>
+                            <label class="flex items-center"><input type="checkbox" id="editor-strike" class="rounded text-indigo-600"><span class="ml-2 text-sm">Strike</span></label>
+                            <label class="flex items-center"><input type="checkbox" id="editor-shadow" class="rounded text-indigo-600"><span class="ml-2 text-sm">Shadow</span></label>
                         </div>
                         <div class="flex justify-end space-x-2">
                             <button id="editor-reset" class="btn-action">Reset</button>
@@ -152,7 +162,19 @@ HAVE FUN
                 "Serif": ["Merriweather", "Lora", "Playfair Display"],
                 "Sans-serif": ["Roboto", "Lato", "Montserrat", "Oswald", "Raleway"],
                 "Display": ["Lobster", "Alfa Slab One", "Bebas Neue", "Pacifico", "Righteous"],
-                "Handwriting": ["Indie Flower", "Patrick Hand", "Dancing Script", "Caveat"]
+                "Handwriting": ["Indie Flower", "Patrick Hand", "Dancing Script", "Caveat"],
+                "Logos & Branding": ["Montserrat", "Bebas Neue", "Julius Sans One"],
+                "Wedding Invitations": ["Great Vibes", "Playfair Display", "Allura"],
+                "Resumes & CVs": ["Open Sans", "Lato", "Alegreya", "Roboto"],
+                "YouTube Thumbnails": ["Bebas Neue", "Oswald", "League Gothic", "Bangers"],
+                "Instagram & Social Posts": ["Alata", "Amatic SC", "Courgette", "Playlist Script"],
+                "Posters & Flyers": ["Bangers", "Anton", "Cantora One", "Cooper Hewitt"],
+                "Business & Corporate": ["Noto Sans", "Source Sans 3", "Sinkin Sans"],
+                "Kids & Children Designs": ["Comic Neue", "Barriecito", "Reef", "Fredoka One"],
+                "Fashion & Luxury Brands": ["Playfair Display", "Vidaloka", "Sacramento"],
+                "Quotes & Inspirational": ["Jonathan", "Brightwall", "Great Vibes"],
+                "Sports & Athletic": ["League Spartan", "Yearbook Solid", "College"],
+                "Magazine & Editorial": ["Merriweather", "Source Serif Pro", "Muller"]
             };
 
             const canvas = document.getElementById('poster-canvas');
@@ -165,17 +187,21 @@ HAVE FUN
             const editorText = document.getElementById('editor-text');
             const editorFont = document.getElementById('editor-font');
             const editorColor = document.getElementById('editor-color');
+            const editorAlpha = document.getElementById('editor-alpha');
             const editorBold = document.getElementById('editor-bold');
             const editorItalic = document.getElementById('editor-italic');
+            const editorStrike = document.getElementById('editor-strike');
+            const editorShadow = document.getElementById('editor-shadow');
             const editorReset = document.getElementById('editor-reset');
             const editorClose = document.getElementById('editor-close');
 
             const controls = {
                 bgColor: document.getElementById('bg-color'),
+                bgAlpha: document.getElementById('bg-alpha'),
                 bgImage: document.getElementById('bg-image'),
                 canvasSize: document.getElementById('canvas-size'),
-                primary: {font: document.getElementById('primary-font'), color: document.getElementById('primary-color'), bold: document.getElementById('primary-bold'), italic: document.getElementById('primary-italic')},
-                secondary: {font: document.getElementById('secondary-font'), color: document.getElementById('secondary-color'), bold: document.getElementById('secondary-bold'), italic: document.getElementById('secondary-italic')}
+                primary: {font: document.getElementById('primary-font'), color: document.getElementById('primary-color'), alpha: document.getElementById('primary-alpha'), bold: document.getElementById('primary-bold'), italic: document.getElementById('primary-italic'), strike: document.getElementById('primary-strike'), shadow: document.getElementById('primary-shadow')},
+                secondary: {font: document.getElementById('secondary-font'), color: document.getElementById('secondary-color'), alpha: document.getElementById('secondary-alpha'), bold: document.getElementById('secondary-bold'), italic: document.getElementById('secondary-italic'), strike: document.getElementById('secondary-strike'), shadow: document.getElementById('secondary-shadow')}
             };
             
             let textItems = [];
@@ -227,6 +253,13 @@ HAVE FUN
             }
 
             function getFontString(item) { return `${item.italic ? 'italic' : ''} ${item.bold ? 'bold' : ''} ${item.fontSize}px "${item.fontFamily}"`; }
+            function hexToRgba(hex, alpha = 1) {
+                const bigint = parseInt(hex.slice(1), 16);
+                const r = (bigint >> 16) & 255;
+                const g = (bigint >> 8) & 255;
+                const b = bigint & 255;
+                return `rgba(${r},${g},${b},${alpha})`;
+            }
             function getFitFontSize(text, item) {
                 const margin = parseInt(marginInput.value, 10) || 0;
                 const targetWidth = canvas.width - (2 * margin);
@@ -254,8 +287,11 @@ HAVE FUN
                         isSecondary: isSecondary,
                         fontFamily: props.font.value,
                         color: props.color.value,
+                        alpha: parseFloat(props.alpha.value),
                         bold: props.bold.checked,
                         italic: props.italic.checked,
+                        strike: props.strike.checked,
+                        shadow: props.shadow.checked,
                         x: canvas.width / 2,
                         y: 0, // temp y
                         isSelected: false,
@@ -316,7 +352,7 @@ HAVE FUN
             }
 
             function draw(isExporting = false) {
-                ctx.fillStyle = controls.bgColor.value;
+                ctx.fillStyle = hexToRgba(controls.bgColor.value, parseFloat(controls.bgAlpha.value));
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
                 if(backgroundImage && backgroundImage.img){
                     ctx.drawImage(backgroundImage.img,
@@ -327,14 +363,31 @@ HAVE FUN
                     if(backgroundImage.isSelected && !isExporting) drawSelectionBox(backgroundImage);
                 }
                 textItems.forEach(item => {
+                    ctx.save();
                     ctx.font = getFontString(item);
                     const metrics = ctx.measureText(item.text);
                     item.width = metrics.width;
                     item.actualHeight = metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent;
                     ctx.fillStyle = item.color;
+                    ctx.globalAlpha = item.alpha;
                     ctx.textAlign = 'center';
                     ctx.textBaseline = 'middle';
+                    if (item.shadow) {
+                        ctx.shadowColor = 'rgba(0,0,0,0.5)';
+                        ctx.shadowBlur = 4;
+                        ctx.shadowOffsetX = 2;
+                        ctx.shadowOffsetY = 2;
+                    }
                     ctx.fillText(item.text, item.x, item.y);
+                    if (item.strike) {
+                        ctx.beginPath();
+                        ctx.moveTo(item.x - item.width/2, item.y);
+                        ctx.lineTo(item.x + item.width/2, item.y);
+                        ctx.lineWidth = 2;
+                        ctx.strokeStyle = item.color;
+                        ctx.stroke();
+                    }
+                    ctx.restore();
                     if (item.isSelected && !isExporting) drawSelectionBox(item);
                 });
             }
@@ -467,8 +520,11 @@ HAVE FUN
                      const props = item.isSecondary ? controls.secondary : controls.primary;
                      item.fontFamily = props.font.value;
                      item.color = props.color.value;
+                     item.alpha = parseFloat(props.alpha.value);
                      item.bold = props.bold.checked;
                      item.italic = props.italic.checked;
+                     item.strike = props.strike.checked;
+                     item.shadow = props.shadow.checked;
                      item.custom = true;
                 });
                 if(selected.length > 0) draw();
@@ -484,8 +540,11 @@ HAVE FUN
                             const props = item.isSecondary ? controls.secondary : controls.primary;
                             item.fontFamily = props.font.value;
                             item.color = props.color.value;
+                            item.alpha = parseFloat(props.alpha.value);
                             item.bold = props.bold.checked;
                             item.italic = props.italic.checked;
+                            item.strike = props.strike.checked;
+                            item.shadow = props.shadow.checked;
                         }
                     });
                     draw();
@@ -497,8 +556,11 @@ HAVE FUN
                 editorText.value = item.text;
                 editorFont.value = item.fontFamily;
                 editorColor.value = item.color;
+                editorAlpha.value = item.alpha;
                 editorBold.checked = item.bold;
                 editorItalic.checked = item.italic;
+                editorStrike.checked = item.strike;
+                editorShadow.checked = item.shadow;
                 editor.classList.remove('hidden');
             }
 
@@ -525,6 +587,12 @@ HAVE FUN
                 currentEditItem.custom = true;
                 draw();
             });
+            editorAlpha.addEventListener('input', () => {
+                if (!currentEditItem) return;
+                currentEditItem.alpha = parseFloat(editorAlpha.value);
+                currentEditItem.custom = true;
+                draw();
+            });
             editorBold.addEventListener('change', () => {
                 if (!currentEditItem) return;
                 currentEditItem.bold = editorBold.checked;
@@ -537,13 +605,28 @@ HAVE FUN
                 currentEditItem.custom = true;
                 draw();
             });
+            editorStrike.addEventListener('change', () => {
+                if (!currentEditItem) return;
+                currentEditItem.strike = editorStrike.checked;
+                currentEditItem.custom = true;
+                draw();
+            });
+            editorShadow.addEventListener('change', () => {
+                if (!currentEditItem) return;
+                currentEditItem.shadow = editorShadow.checked;
+                currentEditItem.custom = true;
+                draw();
+            });
             editorReset.addEventListener('click', () => {
                 if (!currentEditItem) return;
                 const props = currentEditItem.isSecondary ? controls.secondary : controls.primary;
                 currentEditItem.fontFamily = props.font.value;
                 currentEditItem.color = props.color.value;
+                currentEditItem.alpha = parseFloat(props.alpha.value);
                 currentEditItem.bold = props.bold.checked;
                 currentEditItem.italic = props.italic.checked;
+                currentEditItem.strike = props.strike.checked;
+                currentEditItem.shadow = props.shadow.checked;
                 currentEditItem.custom = false;
                 draw();
             });
@@ -555,6 +638,7 @@ HAVE FUN
                 textInput.addEventListener('input', syncTextItems);
                 marginInput.addEventListener('change', syncTextItems);
                 controls.bgColor.addEventListener('input', draw);
+                controls.bgAlpha.addEventListener('input', draw);
                 controls.bgImage.addEventListener('change', handleImageUpload);
                 downloadBtn.addEventListener('click', downloadImage);
                 controls.canvasSize.addEventListener('change', resizeCanvas);

--- a/tools/Poster Creator.html
+++ b/tools/Poster Creator.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>Poster Creator</title>
+    <title>Quick Block Text Poster</title>
     <!-- SEO Tags -->
     <meta name="description" content="Create stunning posters with a powerful online tool. Customize text, fonts, colors, and layouts to design your perfect poster.">
     <meta name="keywords" content="poster creator, design tool, graphic design, custom poster, online editor, typography design">
@@ -57,7 +57,7 @@
     <!-- Controls Panel -->
     <div id="controls-panel" class="w-full lg:w-80 xl:w-96 bg-white shadow-lg flex flex-col flex-shrink-0 transition-all duration-300">
         <div class="p-4 border-b flex justify-between items-center flex-shrink-0">
-            <h1 class="text-xl font-bold text-gray-800">Poster Controls</h1>
+            <h1 class="text-xl font-bold text-gray-800">Quick Block Text Poster</h1>
             <button id="toggle-controls" class="lg:hidden p-2 rounded-md hover:bg-gray-200"><svg id="menu-icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg><svg id="close-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg></button>
         </div>
         <div id="controls-content" class="overflow-y-auto p-4">
@@ -92,6 +92,10 @@ HAVE FUN
             <div class="mb-4">
                 <label for="bg-color" class="block text-sm font-medium text-gray-700 mb-1">Background Color</label>
                 <input type="color" id="bg-color" value="#00008B" class="w-full h-10 p-1 border border-gray-300 rounded-md">
+            </div>
+            <div class="mb-4">
+                <label for="bg-image" class="block text-sm font-medium text-gray-700 mb-1">Background Image</label>
+                <input type="file" id="bg-image" accept="image/*" class="w-full">
             </div>
             <div class="p-4 border rounded-md mb-4 bg-gray-50">
                 <h2 class="text-lg font-semibold mb-2 text-gray-700">Primary Font</h2>
@@ -132,15 +136,18 @@ HAVE FUN
             const canvasContainer = document.getElementById('canvas-container');
             const textInput = document.getElementById('text-input');
             const marginInput = document.getElementById('margin-input');
+            const downloadBtn = document.getElementById('download-btn');
 
             const controls = {
                 bgColor: document.getElementById('bg-color'),
+                bgImage: document.getElementById('bg-image'),
                 canvasSize: document.getElementById('canvas-size'),
                 primary: {font: document.getElementById('primary-font'), color: document.getElementById('primary-color'), bold: document.getElementById('primary-bold'), italic: document.getElementById('primary-italic')},
                 secondary: {font: document.getElementById('secondary-font'), color: document.getElementById('secondary-color'), bold: document.getElementById('secondary-bold'), italic: document.getElementById('secondary-italic')}
             };
             
             let textItems = [];
+            let backgroundImage = null;
             let lastMousePos = { x: 0, y: 0 };
             const RESIZE_HANDLE_SIZE = 20;
             const sizes = { tall: { width: 1080, height: 1920 }, wide: { width: 1920, height: 1080 }, square: { width: 1080, height: 1080 } };
@@ -245,9 +252,47 @@ HAVE FUN
                 draw();
             }
 
+            function handleImageUpload(e) {
+                const file = e.target.files[0];
+                if (!file) return;
+                const img = new Image();
+                img.onload = () => {
+                    backgroundImage = {
+                        img,
+                        x: canvas.width / 2,
+                        y: canvas.height / 2,
+                        width: canvas.width,
+                        height: canvas.height,
+                        actualHeight: canvas.height,
+                        isSelected: false,
+                        action: null
+                    };
+                    draw();
+                };
+                img.src = URL.createObjectURL(file);
+            }
+
+            function downloadImage() {
+                const link = document.createElement('a');
+                canvas.toBlob(blob => {
+                    link.href = URL.createObjectURL(blob);
+                    link.download = 'poster.jpg';
+                    link.click();
+                    URL.revokeObjectURL(link.href);
+                }, 'image/jpeg');
+            }
+
             function draw(isExporting = false) {
                 ctx.fillStyle = controls.bgColor.value;
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
+                if(backgroundImage && backgroundImage.img){
+                    ctx.drawImage(backgroundImage.img,
+                        backgroundImage.x - backgroundImage.width/2,
+                        backgroundImage.y - backgroundImage.height/2,
+                        backgroundImage.width,
+                        backgroundImage.height);
+                    if(backgroundImage.isSelected && !isExporting) drawSelectionBox(backgroundImage);
+                }
                 textItems.forEach(item => {
                     ctx.font = getFontString(item);
                     const metrics = ctx.measureText(item.text);
@@ -296,13 +341,14 @@ HAVE FUN
             };
             
             function getActionTarget(p) {
-                for (const item of [...textItems].reverse()) {
+                const items = backgroundImage ? [backgroundImage, ...textItems] : [...textItems];
+                for (const item of [...items].reverse()) {
                     if (item.isSelected) {
                         const bR = { x: item.x + item.width / 2, y: item.y + item.actualHeight / 2 };
                         if (Math.sqrt(Math.pow(p.x - (bR.x + 5), 2) + Math.pow(p.y - (bR.y + 5), 2)) < RESIZE_HANDLE_SIZE) return { item, action: 'resizing' };
                     }
                 }
-                for (const item of [...textItems].reverse()) {
+                for (const item of [...items].reverse()) {
                     if (p.x > item.x - item.width/2 && p.x < item.x + item.width/2 && p.y > item.y - item.actualHeight/2 && p.y < item.y + item.actualHeight/2) return { item, action: 'dragging' };
                 }
                 return null;
@@ -314,10 +360,16 @@ HAVE FUN
                 lastMousePos = pos;
                 const target = getActionTarget(pos);
 
+                const all = backgroundImage ? [backgroundImage, ...textItems] : [...textItems];
                 if (target) {
-                    if (!e.shiftKey && !target.item.isSelected) textItems.forEach(i => i.isSelected = false);
-                    target.item.isSelected = true;
-                    textItems.forEach(i => {
+                    if (e.shiftKey) {
+                        target.item.isSelected = !target.item.isSelected;
+                    } else {
+                        all.forEach(i => i.isSelected = false);
+                        target.item.isSelected = true;
+                    }
+
+                    all.forEach(i => {
                         if (i.isSelected) {
                             i.action = target.action;
                             i.dragOffset = { x: pos.x - i.x, y: pos.y - i.y };
@@ -326,7 +378,7 @@ HAVE FUN
                         }
                     });
                 } else {
-                    textItems.forEach(i => i.isSelected = false);
+                    all.forEach(i => i.isSelected = false);
                 }
                 draw();
             }
@@ -335,7 +387,9 @@ HAVE FUN
                 e.preventDefault();
                 const pos = getCanvasPos(e);
                 let needsRedraw = false;
-                const selectedItems = textItems.filter(i => i.isSelected && i.action);
+                const selectedItems = [];
+                if (backgroundImage && backgroundImage.isSelected && backgroundImage.action) selectedItems.push(backgroundImage);
+                selectedItems.push(...textItems.filter(i => i.isSelected && i.action));
                 if (selectedItems.length === 0) return;
 
                 if (selectedItems[0].action === 'dragging') {
@@ -353,11 +407,16 @@ HAVE FUN
                     const dx = pos.x - lastMousePos.x;
                     const newWidth = Math.max(20, resizingItem.width + dx);
                     const scale = newWidth / resizingItem.width;
-                    
+
                     selectedItems.forEach(item => {
-                        item.fontSize = item.dragStart.fontSize * scale;
+                        if (item.fontSize) {
+                            item.fontSize = item.dragStart.fontSize * scale;
+                        }
                         const newW = item.dragStart.width * scale;
                         const newH = item.dragStart.height * scale;
+                        item.width = newW;
+                        item.actualHeight = newH;
+                        if (item.height !== undefined) item.height = newH;
                         item.x = item.topLeftStart.x + newW/2;
                         item.y = item.topLeftStart.y + newH/2;
                     });
@@ -384,17 +443,28 @@ HAVE FUN
                 textInput.addEventListener('input', syncTextItems);
                 marginInput.addEventListener('change', syncTextItems);
                 controls.bgColor.addEventListener('input', draw);
+                controls.bgImage.addEventListener('change', handleImageUpload);
+                downloadBtn.addEventListener('click', downloadImage);
                 controls.canvasSize.addEventListener('change', resizeCanvas);
                 Object.values(controls.primary).forEach(el => el.addEventListener('input', applyStyleToSelection));
                 Object.values(controls.secondary).forEach(el => el.addEventListener('input', applyStyleToSelection));
                 window.addEventListener('resize', resizeCanvas);
                 canvas.addEventListener('mousedown', handleMouseDown);
                 canvas.addEventListener('mousemove', handleMouseMove);
-                canvas.addEventListener('mouseup', () => textItems.forEach(i=>i.action=null));
-                canvas.addEventListener('mouseleave', () => textItems.forEach(i=>i.action=null));
+                canvas.addEventListener('mouseup', () => {
+                    textItems.forEach(i=>i.action=null);
+                    if (backgroundImage) backgroundImage.action=null;
+                });
+                canvas.addEventListener('mouseleave', () => {
+                    textItems.forEach(i=>i.action=null);
+                    if (backgroundImage) backgroundImage.action=null;
+                });
                 canvas.addEventListener('touchstart', handleMouseDown, { passive: false });
                 canvas.addEventListener('touchmove', handleMouseMove, { passive: false });
-                canvas.addEventListener('touchend', () => textItems.forEach(i=>i.action=null));
+                canvas.addEventListener('touchend', () => {
+                    textItems.forEach(i=>i.action=null);
+                    if (backgroundImage) backgroundImage.action=null;
+                });
             }
             loadFonts();
         });

--- a/tools/Poster Creator.html
+++ b/tools/Poster Creator.html
@@ -119,8 +119,32 @@ HAVE FUN
                 <span id="fullscreen-text">Full Screen</span>
             </button>
         </div>
-        <canvas id="poster-canvas" class="bg-white shadow-lg rounded-md"></canvas>
-    </div>
+                <canvas id="poster-canvas" class="bg-white shadow-lg rounded-md"></canvas>
+                <div id="item-editor" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+                    <div class="bg-white p-4 rounded-md shadow-lg w-72">
+                        <div class="mb-2">
+                            <label for="editor-text" class="block text-sm font-medium text-gray-700 mb-1">Text</label>
+                            <input id="editor-text" type="text" class="w-full p-1 border border-gray-300 rounded-md">
+                        </div>
+                        <div class="mb-2">
+                            <label for="editor-font" class="block text-sm font-medium text-gray-700 mb-1">Font</label>
+                            <select id="editor-font" class="w-full p-1 border border-gray-300 rounded-md"></select>
+                        </div>
+                        <div class="mb-2">
+                            <label for="editor-color" class="block text-sm font-medium text-gray-700 mb-1">Color</label>
+                            <input id="editor-color" type="color" class="w-full h-8 p-0 border border-gray-300 rounded-md">
+                        </div>
+                        <div class="flex items-center space-x-4 mb-4">
+                            <label class="flex items-center"><input type="checkbox" id="editor-bold" class="rounded text-indigo-600"><span class="ml-2 text-sm">Bold</span></label>
+                            <label class="flex items-center"><input type="checkbox" id="editor-italic" class="rounded text-indigo-600"><span class="ml-2 text-sm">Italic</span></label>
+                        </div>
+                        <div class="flex justify-end space-x-2">
+                            <button id="editor-reset" class="btn-action">Reset</button>
+                            <button id="editor-close" class="btn-action">Close</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
@@ -137,6 +161,14 @@ HAVE FUN
             const textInput = document.getElementById('text-input');
             const marginInput = document.getElementById('margin-input');
             const downloadBtn = document.getElementById('download-btn');
+            const editor = document.getElementById('item-editor');
+            const editorText = document.getElementById('editor-text');
+            const editorFont = document.getElementById('editor-font');
+            const editorColor = document.getElementById('editor-color');
+            const editorBold = document.getElementById('editor-bold');
+            const editorItalic = document.getElementById('editor-italic');
+            const editorReset = document.getElementById('editor-reset');
+            const editorClose = document.getElementById('editor-close');
 
             const controls = {
                 bgColor: document.getElementById('bg-color'),
@@ -147,13 +179,14 @@ HAVE FUN
             };
             
             let textItems = [];
+            let currentEditItem = null;
             let backgroundImage = null;
             let lastMousePos = { x: 0, y: 0 };
             const RESIZE_HANDLE_SIZE = 20;
             const sizes = { tall: { width: 1080, height: 1920 }, wide: { width: 1920, height: 1080 }, square: { width: 1080, height: 1080 } };
 
             function populateFontSelectors() {
-                const selects = [controls.primary.font, controls.secondary.font];
+                const selects = [controls.primary.font, controls.secondary.font, editorFont];
                 selects.forEach(select => {
                     select.innerHTML = '';
                     for (const category in FONT_LIST) {
@@ -359,12 +392,15 @@ HAVE FUN
                 const pos = getCanvasPos(e);
                 lastMousePos = pos;
                 const target = getActionTarget(pos);
-
                 const all = backgroundImage ? [backgroundImage, ...textItems] : [...textItems];
                 if (target) {
+                    if (e.ctrlKey && !target.item.img) {
+                        openItemEditor(target.item);
+                        return;
+                    }
                     if (e.shiftKey) {
                         target.item.isSelected = !target.item.isSelected;
-                    } else {
+                    } else if (!target.item.isSelected) {
                         all.forEach(i => i.isSelected = false);
                         target.item.isSelected = true;
                     }
@@ -378,7 +414,7 @@ HAVE FUN
                         }
                     });
                 } else {
-                    all.forEach(i => i.isSelected = false);
+                    if (!e.shiftKey) all.forEach(i => i.isSelected = false);
                 }
                 draw();
             }
@@ -433,9 +469,85 @@ HAVE FUN
                      item.color = props.color.value;
                      item.bold = props.bold.checked;
                      item.italic = props.italic.checked;
+                     item.custom = true;
                 });
                 if(selected.length > 0) draw();
             }
+
+            function handleGlobalStyleChange() {
+                const selected = textItems.filter(i => i.isSelected);
+                if (selected.length) {
+                    applyStyleToSelection();
+                } else {
+                    textItems.forEach(item => {
+                        if (!item.custom) {
+                            const props = item.isSecondary ? controls.secondary : controls.primary;
+                            item.fontFamily = props.font.value;
+                            item.color = props.color.value;
+                            item.bold = props.bold.checked;
+                            item.italic = props.italic.checked;
+                        }
+                    });
+                    draw();
+                }
+            }
+
+            function openItemEditor(item) {
+                currentEditItem = item;
+                editorText.value = item.text;
+                editorFont.value = item.fontFamily;
+                editorColor.value = item.color;
+                editorBold.checked = item.bold;
+                editorItalic.checked = item.italic;
+                editor.classList.remove('hidden');
+            }
+
+            function closeItemEditor() {
+                currentEditItem = null;
+                editor.classList.add('hidden');
+            }
+
+            editorText.addEventListener('input', () => {
+                if (!currentEditItem) return;
+                currentEditItem.text = editorText.value;
+                currentEditItem.custom = true;
+                draw();
+            });
+            editorFont.addEventListener('input', () => {
+                if (!currentEditItem) return;
+                currentEditItem.fontFamily = editorFont.value;
+                currentEditItem.custom = true;
+                draw();
+            });
+            editorColor.addEventListener('input', () => {
+                if (!currentEditItem) return;
+                currentEditItem.color = editorColor.value;
+                currentEditItem.custom = true;
+                draw();
+            });
+            editorBold.addEventListener('change', () => {
+                if (!currentEditItem) return;
+                currentEditItem.bold = editorBold.checked;
+                currentEditItem.custom = true;
+                draw();
+            });
+            editorItalic.addEventListener('change', () => {
+                if (!currentEditItem) return;
+                currentEditItem.italic = editorItalic.checked;
+                currentEditItem.custom = true;
+                draw();
+            });
+            editorReset.addEventListener('click', () => {
+                if (!currentEditItem) return;
+                const props = currentEditItem.isSecondary ? controls.secondary : controls.primary;
+                currentEditItem.fontFamily = props.font.value;
+                currentEditItem.color = props.color.value;
+                currentEditItem.bold = props.bold.checked;
+                currentEditItem.italic = props.italic.checked;
+                currentEditItem.custom = false;
+                draw();
+            });
+            editorClose.addEventListener('click', closeItemEditor);
             
             function init() {
                 populateFontSelectors();
@@ -446,8 +558,8 @@ HAVE FUN
                 controls.bgImage.addEventListener('change', handleImageUpload);
                 downloadBtn.addEventListener('click', downloadImage);
                 controls.canvasSize.addEventListener('change', resizeCanvas);
-                Object.values(controls.primary).forEach(el => el.addEventListener('input', applyStyleToSelection));
-                Object.values(controls.secondary).forEach(el => el.addEventListener('input', applyStyleToSelection));
+                Object.values(controls.primary).forEach(el => el.addEventListener('input', handleGlobalStyleChange));
+                Object.values(controls.secondary).forEach(el => el.addEventListener('input', handleGlobalStyleChange));
                 window.addEventListener('resize', resizeCanvas);
                 canvas.addEventListener('mousedown', handleMouseDown);
                 canvas.addEventListener('mousemove', handleMouseMove);


### PR DESCRIPTION
## Summary
- rename heading to *Quick Block Text Poster*
- allow uploading a draggable/resizable background image
- enable download button
- improve selection logic with shift-click toggle

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845766716d8832bae8d494630101486