### PR TITLE
Add editor for CSV and tool pages

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Edit Repository Files</title>
+  <link rel="stylesheet" href="https://cdn.muicss.com/mui-latest/css/mui.min.css">
+  <style>
+    body { padding: 1rem; }
+    textarea { width: 100%; height: 300px; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>Edit Repository Files</h1>
+
+  <div class="mui-textfield">
+    <input type="text" id="token" placeholder="GitHub Token">
+  </div>
+  <div class="mui-textfield">
+    <input type="text" id="owner" placeholder="Owner">
+  </div>
+  <div class="mui-textfield">
+    <input type="text" id="repo" placeholder="Repository">
+  </div>
+  <button id="save-auth" class="mui-btn mui-btn--primary">Save Auth</button>
+
+  <h2>external-sites.csv</h2>
+  <button id="load-csv" class="mui-btn">Load CSV</button>
+  <button id="save-csv" class="mui-btn mui-btn--primary">Save CSV</button>
+  <textarea id="csv-content" placeholder="CSV content will appear here"></textarea>
+
+  <h2>Tool File</h2>
+  <div class="mui-textfield">
+    <input type="text" id="tool-path" placeholder="tools/MyTool.html">
+  </div>
+  <button id="load-tool" class="mui-btn">Load File</button>
+  <button id="save-tool" class="mui-btn mui-btn--primary">Save File</button>
+  <textarea id="tool-content" placeholder="Tool HTML content"></textarea>
+
+  <script src="edit.js" defer></script>
+</body>
+</html>

--- a/edit.js
+++ b/edit.js
@@ -1,0 +1,87 @@
+(function() {
+  const tokenInput = document.getElementById('token');
+  const ownerInput = document.getElementById('owner');
+  const repoInput = document.getElementById('repo');
+  const saveAuthBtn = document.getElementById('save-auth');
+  const csvArea = document.getElementById('csv-content');
+  const loadCsvBtn = document.getElementById('load-csv');
+  const saveCsvBtn = document.getElementById('save-csv');
+  const toolPathInput = document.getElementById('tool-path');
+  const toolArea = document.getElementById('tool-content');
+  const loadToolBtn = document.getElementById('load-tool');
+  const saveToolBtn = document.getElementById('save-tool');
+
+  const shas = {};
+
+  // Populate from localStorage
+  tokenInput.value = localStorage.getItem('gh_token') || '';
+  ownerInput.value = localStorage.getItem('gh_owner') || '';
+  repoInput.value = localStorage.getItem('gh_repo') || '';
+
+  saveAuthBtn.addEventListener('click', () => {
+    localStorage.setItem('gh_token', tokenInput.value.trim());
+    localStorage.setItem('gh_owner', ownerInput.value.trim());
+    localStorage.setItem('gh_repo', repoInput.value.trim());
+    alert('Auth info saved');
+  });
+
+  function authHeaders() {
+    const token = tokenInput.value.trim();
+    return token ? { Authorization: `token ${token}` } : {};
+  }
+
+  function repoUrl(path) {
+    const owner = ownerInput.value.trim();
+    const repo = repoInput.value.trim();
+    return `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`;
+  }
+
+  async function loadFile(path, area) {
+    const res = await fetch(repoUrl(path), { headers: authHeaders() });
+    if (res.status === 404) {
+      area.value = '';
+      shas[path] = null;
+      return;
+    }
+    if (!res.ok) {
+      alert('Failed to load file: ' + res.status);
+      return;
+    }
+    const data = await res.json();
+    area.value = atob(data.content.replace(/\n/g, ''));
+    shas[path] = data.sha;
+  }
+
+  async function saveFile(path, area, message) {
+    const body = {
+      message,
+      content: btoa(area.value),
+    };
+    if (shas[path]) body.sha = shas[path];
+    const res = await fetch(repoUrl(path), {
+      method: 'PUT',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders()),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      alert('Save failed: ' + text);
+      return;
+    }
+    const data = await res.json();
+    shas[path] = data.content.sha;
+    alert('Saved');
+  }
+
+  loadCsvBtn.addEventListener('click', () => loadFile('external-sites.csv', csvArea));
+  saveCsvBtn.addEventListener('click', () => saveFile('external-sites.csv', csvArea, 'Update external sites'));
+
+  loadToolBtn.addEventListener('click', () => {
+    const path = toolPathInput.value.trim();
+    if (path) loadFile(path, toolArea);
+  });
+  saveToolBtn.addEventListener('click', () => {
+    const path = toolPathInput.value.trim();
+    if (path) saveFile(path, toolArea, `Update ${path}`);
+  });
+})();


### PR DESCRIPTION
## Summary
- add `edit.html` to provide a lightweight interface for editing repository files
- implement `edit.js` for GitHub API interactions via a saved personal access token

## Testing
- `npm run generate` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68458d936024832bbd082711afcf2e4f