### PR TITLE
Fix scrolling in gallery index

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
       margin: 0;
       display: flex;
       height: 100vh;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
     #sidebar {
       width: 250px;


### PR DESCRIPTION
## Summary
- allow the main page to scroll when the grid overflows

## Testing
- `npm run generate` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684689fde430832ba692049991b1cdd3