### PR TITLE
Add edit button and GitHub token check

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -12,6 +12,7 @@
   const saveFileBtn = document.getElementById('save-file');
   const currentPathEl = document.getElementById('current-path');
   const textArea = document.getElementById('file-content');
+  const startPath = decodeURIComponent(location.hash.slice(1));
 
   const shas = {};
   let editor;
@@ -53,7 +54,7 @@
         authSection.style.display = 'none';
         editorSection.style.display = 'flex';
         await listFiles();
-        loadFile('external-sites.csv');
+        loadFile(startPath || 'external-sites.csv');
       } else {
         authSection.style.display = 'block';
         editorSection.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
       <div id="viewer-controls" style="padding:0.5rem; border-bottom:1px solid #ddd;">
         <button id="back-button" class="mui-btn mui-btn--small">Back</button>
         <button id="toggle-info" class="mui-btn mui-btn--small">Hide Info</button>
+        <button id="edit-button" class="mui-btn mui-btn--small" style="display:none;">Edit</button>
       </div>
       <img id="viewer-placeholder" style="display:none; width:100%; flex:1; object-fit:cover;"/>
       <iframe id="tool-frame" style="display:none;"></iframe>

--- a/index.js
+++ b/index.js
@@ -58,7 +58,20 @@ async function init() {
   const keysEl = document.getElementById('tool-keywords');
   const backBtn = document.getElementById('back-button');
   const toggleInfoBtn = document.getElementById('toggle-info');
+  const editBtn = document.getElementById('edit-button');
   const infoEl = document.getElementById('tool-info');
+
+  function hasGhAuth() {
+    return (
+      localStorage.getItem('gh_token') &&
+      localStorage.getItem('gh_owner') &&
+      localStorage.getItem('gh_repo')
+    );
+  }
+
+  if (hasGhAuth()) {
+    editBtn.style.display = 'inline-block';
+  }
 
   function matches(tool, q) {
     q = q.toLowerCase();
@@ -193,6 +206,12 @@ async function init() {
       infoEl.style.display = 'none';
       toggleInfoBtn.textContent = 'Show Info';
     }
+  });
+
+  editBtn.addEventListener('click', () => {
+    const file = decodeURIComponent(location.hash.slice(1));
+    const url = file ? `edit.html#${encodeURIComponent(file)}` : 'edit.html';
+    location.href = url;
   });
 
   window.addEventListener('hashchange', () => {


### PR DESCRIPTION
## Summary
- allow editing of tools when GitHub token is present
- expose edit button in viewer controls
- pass file path to edit page so the editor opens the correct file

## Testing
- `npm run generate` *(fails: fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847b181aa48832b8d75e35de6f9fa0e