### PR TITLE
Add edit link and token-based file loading

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -18,6 +18,7 @@
   const shas = {};
   let editor;
   let currentPath = '';
+  const requestedFile = new URLSearchParams(location.search).get('file');
 
   // Initialize CodeMirror
   editor = CodeMirror.fromTextArea(textArea, {
@@ -80,7 +81,11 @@
     hideAuth();
     const listed = await listFiles();
     if (listed) {
-      loadFile('external-sites.csv');
+      if (requestedFile) {
+        loadFile(requestedFile);
+      } else {
+        loadFile('external-sites.csv');
+      }
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
       <div id="viewer-controls" style="padding:0.5rem; border-bottom:1px solid #ddd;">
         <button id="back-button" class="mui-btn mui-btn--small">Back</button>
         <button id="toggle-info" class="mui-btn mui-btn--small">Hide Info</button>
+        <button id="edit-file" class="mui-btn mui-btn--small" style="display:none;">Edit File</button>
       </div>
       <img id="viewer-placeholder" style="display:none; width:100%; flex:1; object-fit:cover;"/>
       <iframe id="tool-frame" style="display:none;"></iframe>

--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ async function init() {
   const backBtn = document.getElementById('back-button');
   const toggleInfoBtn = document.getElementById('toggle-info');
   const infoEl = document.getElementById('tool-info');
+  const editFileBtn = document.getElementById('edit-file');
+  let selectedTool = null;
 
   function matches(tool, q) {
     q = q.toLowerCase();
@@ -138,9 +140,15 @@ async function init() {
   function showViewer() {
     gridEl.style.display = 'none';
     viewerEl.style.display = 'flex';
+    if (localStorage.getItem('gh_token')) {
+      editFileBtn.style.display = 'inline-block';
+    } else {
+      editFileBtn.style.display = 'none';
+    }
   }
 
   async function selectTool(tool, updateHash = true) {
+    selectedTool = tool;
     frameEl.style.display = 'none';
     const shot = await getScreenshot(tool.file);
     if (shot) {
@@ -192,6 +200,12 @@ async function init() {
     } else {
       infoEl.style.display = 'none';
       toggleInfoBtn.textContent = 'Show Info';
+    }
+  });
+
+  editFileBtn.addEventListener('click', () => {
+    if (selectedTool) {
+      location.href = `edit.html?file=${encodeURIComponent(selectedTool.file)}`;
     }
   });
 


### PR DESCRIPTION
## Summary
- add `Edit File` button in viewer
- toggle edit button depending on token
- link to editor with the selected file
- allow editor to open a file from query string

## Testing
- `npm run generate` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6847b3952a48832baca816d5d7bd452e