### PR TITLE
Update screenshot frame size

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,12 +35,7 @@
       display: grid;
       gap: 1rem;
       padding: 1rem;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    }
-    @media (min-width: 1000px) {
-      #grid-view {
-        grid-template-columns: repeat(3, 1fr);
-      }
+      grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
     }
     .tool-card {
       border: 1px solid #ddd;
@@ -48,7 +43,7 @@
       padding: 1rem;
     }
     .card-frame {
-      width: 100%;
+      width: 450px;
       height: 220px;
       border: 0;
       margin-bottom: 0.5rem;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,12 @@ async function saveScreenshot(file, data) {
 async function captureScreenshot(iframe) {
   try {
     const doc = iframe.contentWindow.document;
-    const canvas = await html2canvas(doc.body);
+    const canvas = await html2canvas(doc.body, {
+      width: 450,
+      height: 220,
+      windowWidth: 450,
+      windowHeight: 220,
+    });
     return canvas.toDataURL('image/png');
   } catch (err) {
     console.warn('Unable to capture screenshot for', iframe.src, err);


### PR DESCRIPTION
## Summary
- capture screenshots at 450×220
- display screenshot frames with fixed 450×220 size
- adjust grid column min width accordingly

## Testing
- `npm run generate` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847c1a94f14832bb0b5f3f4ae2aac01