### PR TITLE
Show similar tools using keyword matches

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -15,6 +15,28 @@ async function generateTools() {
     const keywords = keyMatch ? keyMatch[1].split(',').map(k => k.trim()).filter(Boolean) : [];
     return { file: `tools/${file}`, title, description, keywords };
   });
+  // determine related tools based on shared keyword tokens
+  const wordSets = tools.map(t =>
+    new Set(
+      t.keywords
+        .flatMap(k => k.toLowerCase().split(/\s+/))
+        .filter(Boolean)
+    )
+  );
+  tools.forEach((tool, idx) => {
+    const scores = tools
+      .map((t, j) => {
+        if (j === idx) return { file: t.file, count: 0 };
+        let count = 0;
+        for (const w of wordSets[idx]) if (wordSets[j].has(w)) count++;
+        return { file: t.file, count };
+      })
+      .filter(s => s.count > 0)
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 3)
+      .map(s => s.file);
+    tool.related = scores;
+  });
   fs.writeFileSync(path.join(__dirname, 'tools.json'), JSON.stringify(tools, null, 2) + '\n');
 }
 

--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@
         <h3 id="tool-title"></h3>
         <p id="tool-description"></p>
         <small id="tool-keywords"></small>
+        <p id="tool-related" style="margin-top:0.5rem;"></p>
       </div>
     </div>
   </div>

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ async function init() {
   const titleEl = document.getElementById('tool-title');
   const descEl = document.getElementById('tool-description');
   const keysEl = document.getElementById('tool-keywords');
+  const relatedEl = document.getElementById('tool-related');
   const backBtn = document.getElementById('back-button');
   const toggleInfoBtn = document.getElementById('toggle-info');
   const infoEl = document.getElementById('tool-info');
@@ -172,6 +173,24 @@ async function init() {
       tool.keywords && tool.keywords.length
         ? 'Keywords: ' + tool.keywords.join(', ')
         : '';
+    relatedEl.innerHTML = '';
+    if (tool.related && tool.related.length) {
+      relatedEl.appendChild(document.createTextNode('Similar: '));
+      tool.related.forEach((file, idx) => {
+        const relTool = allTools.find(t => t.file === file);
+        if (relTool) {
+          const link = document.createElement('a');
+          link.href = '#';
+          link.textContent = relTool.title;
+          link.addEventListener('click', e => {
+            e.preventDefault();
+            selectTool(relTool);
+          });
+          if (idx > 0) relatedEl.appendChild(document.createTextNode(', '));
+          relatedEl.appendChild(link);
+        }
+      });
+    }
     showViewer();
     if (updateHash) {
       location.hash = encodeURIComponent(tool.file);

--- a/tools.json
+++ b/tools.json
@@ -12,11 +12,16 @@
       "visual calendar",
       "project schedule",
       "free tool"
+    ],
+    "related": [
+      "tools/Masonry Image Collage Generator.html",
+      "tools/Image Resizer and Cropper.html",
+      "tools/Poster Creator.html"
     ]
   },
   {
     "file": "tools/Image Resizer and Cropper.html",
-    "title": "Free Image Resizer & Cropper - Online Tool",
+    "title": "Image Resizer and Cropper",
     "description": "A free online tool to resize, crop, and edit images for any purpose. Perfect for creating favicons, app icons (Chrome extensions, web apps), and social media assets. Features zoom, pan, and custom background colors.",
     "keywords": [
       "image resizer",
@@ -29,11 +34,16 @@
       "jpeg resizer",
       "chrome extension icons",
       "web app icons"
+    ],
+    "related": [
+      "tools/Masonry Image Collage Generator.html",
+      "tools/Poster Creator.html",
+      "tools/Calendar Timeline Visualizer.html"
     ]
   },
   {
     "file": "tools/Masonry Image Collage Generator.html",
-    "title": "Free Masonry Image Collage Generator | Create & Download Collages",
+    "title": "Masonry Image Collage Generator",
     "description": "Easily create, customize, and download beautiful masonry-style image and video collages online for free. No sign-up required. Upload your files, adjust layouts, and share your creation.",
     "keywords": [
       "image collage",
@@ -46,6 +56,11 @@
       "picture collage",
       "download collage",
       "create collage"
+    ],
+    "related": [
+      "tools/Image Resizer and Cropper.html",
+      "tools/Calendar Timeline Visualizer.html",
+      "tools/Poster Creator.html"
     ]
   },
   {
@@ -59,6 +74,11 @@
       "custom poster",
       "online editor",
       "typography design"
+    ],
+    "related": [
+      "tools/Image Resizer and Cropper.html",
+      "tools/Calendar Timeline Visualizer.html",
+      "tools/Masonry Image Collage Generator.html"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- compute related tools based on shared keywords when generating data
- display related tools in the viewer UI

## Testing
- `node --check index.js`
- `node generate.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6847c636da5c832ba5eca58ea0aac6d4