### PR TITLE
Use Polymer app-layout

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -6,17 +6,25 @@
   <title>Edit Repository Files</title>
   <link rel="stylesheet" href="https://cdn.muicss.com/mui-latest/css/mui.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.min.css">
+  <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2/webcomponents-loader.js"></script>
+  <script type="module">
+    import 'https://unpkg.com/@polymer/app-layout/app-layout.js?module';
+  </script>
   <style>
-    body { margin:0; height:100vh; display:flex; overflow:hidden; }
+    html, body { margin:0; height:100%; }
     #auth-section { padding:1rem; width:100%; }
-    #editor-section { flex:1; display:flex; }
+    #editor-section { height:100%; }
+    app-drawer-layout { height:100%; }
     #sidebar { width:220px; border-right:1px solid #ddd; padding:1rem; overflow-y:auto; }
     #main { flex:1; display:flex; flex-direction:column; padding:1rem; }
     #file-content { height:100%; }
     .CodeMirror { height:100%; }
+    app-drawer-layout:not([narrow]) [drawer-toggle] {
+      display:none;
+    }
   </style>
 </head>
-<body>
+<body unresolved>
   <div id="auth-section">
     <h1>Edit Repository Files</h1>
     <div class="mui-textfield">
@@ -26,24 +34,34 @@
     <button id="save-auth" class="mui-btn mui-btn--primary">Save Auth</button>
   </div>
 
-  <div id="editor-section" style="display:none;">
-    <div id="sidebar">
-      <ul id="file-list" class="mui-list--unstyled"></ul>
-      <div class="mui-textfield" style="margin-top:1rem;">
-        <input type="text" id="new-file-name" placeholder="New file name.html">
+  <app-drawer-layout id="editor-section" style="display:none;" fullbleed>
+    <app-drawer slot="drawer">
+      <div id="sidebar">
+        <ul id="file-list" class="mui-list--unstyled"></ul>
+        <div class="mui-textfield" style="margin-top:1rem;">
+          <input type="text" id="new-file-name" placeholder="New file name.html">
+        </div>
+        <button id="create-file" class="mui-btn mui-btn--small mui-btn--primary">Create</button>
       </div>
-      <button id="create-file" class="mui-btn mui-btn--small mui-btn--primary">Create</button>
-    </div>
-    <div id="main">
-      <h2 id="current-path"></h2>
-      <textarea id="file-content"></textarea>
-      <div style="margin-top:0.5rem;">
-        <button id="save-file" class="mui-btn mui-btn--primary">Save</button>
-        <button id="rename-file" class="mui-btn mui-btn--small">Rename</button>
-        <button id="delete-file" class="mui-btn mui-btn--danger mui-btn--small">Delete</button>
+    </app-drawer>
+    <app-header-layout has-scrolling-region>
+      <app-header slot="header" fixed>
+        <app-toolbar>
+          <button drawer-toggle class="mui-btn mui-btn--small">Menu</button>
+          <div main-title>Edit Files</div>
+        </app-toolbar>
+      </app-header>
+      <div id="main">
+        <h2 id="current-path"></h2>
+        <textarea id="file-content"></textarea>
+        <div style="margin-top:0.5rem;">
+          <button id="save-file" class="mui-btn mui-btn--primary">Save</button>
+          <button id="rename-file" class="mui-btn mui-btn--small">Rename</button>
+          <button id="delete-file" class="mui-btn mui-btn--danger mui-btn--small">Delete</button>
+        </div>
       </div>
-    </div>
-  </div>
+    </app-header-layout>
+  </app-drawer-layout>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/mode/xml/xml.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -11,14 +11,18 @@
   <link rel="preload" href="index.js" as="script">
   <script src="https://unpkg.com/dexie@latest/dist/dexie.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+  <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2/webcomponents-loader.js"></script>
+  <script type="module">
+    import 'https://unpkg.com/@polymer/app-layout/app-layout.js?module';
+  </script>
   <link rel="stylesheet" href="https://cdn.muicss.com/mui-latest/css/mui.min.css">
   <style>
-    body {
+    html, body {
       margin: 0;
-      display: flex;
-      height: 100vh;
-      overflow-x: hidden;
-      overflow-y: auto;
+      height: 100%;
+    }
+    app-drawer-layout {
+      height: 100%;
     }
     #sidebar {
       width: 250px;
@@ -68,8 +72,10 @@
       padding: 1rem;
       border-top: 1px solid #ddd;
     }
+    app-drawer-layout:not([narrow]) [drawer-toggle] {
+      display: none;
+    }
     @media (max-width: 600px) {
-      body { flex-direction: column; }
       #sidebar {
         width: 100%;
         border-right: none;
@@ -78,30 +84,44 @@
     }
   </style>
 </head>
-<body>
-  <div id="sidebar">
-    <div class="mui-textfield">
-      <input type="text" id="search" placeholder="Search tools">
-    </div>
-    <ul id="tool-list" class="mui-list--unstyled"></ul>
-  </div>
-  <div id="main">
-    <div id="grid-view"></div>
-    <div id="viewer" style="display:none; flex:1; flex-direction:column;">
-      <div id="viewer-controls" style="padding:0.5rem; border-bottom:1px solid #ddd;">
-        <button id="back-button" class="mui-btn mui-btn--small">Back</button>
-        <button id="toggle-info" class="mui-btn mui-btn--small">Hide Info</button>
-        <button id="edit-file" class="mui-btn mui-btn--small" style="display:none;">Edit File</button>
+<body unresolved>
+  <app-drawer-layout fullbleed>
+    <app-drawer slot="drawer">
+      <div id="sidebar">
+        <div class="mui-textfield">
+          <input type="text" id="search" placeholder="Search tools">
+        </div>
+        <ul id="tool-list" class="mui-list--unstyled"></ul>
       </div>
-      <img id="viewer-placeholder" style="display:none; width:100%; flex:1; object-fit:cover;"/>
-      <iframe id="tool-frame" style="display:none;"></iframe>
-      <div id="tool-info">
-        <h3 id="tool-title"></h3>
-        <p id="tool-description"></p>
-        <small id="tool-keywords"></small>
+    </app-drawer>
+
+    <app-header-layout has-scrolling-region>
+      <app-header slot="header" fixed>
+        <app-toolbar>
+          <button drawer-toggle class="mui-btn mui-btn--small">Menu</button>
+          <div main-title>Tool Gallery</div>
+        </app-toolbar>
+      </app-header>
+
+      <div id="main">
+        <div id="grid-view"></div>
+        <div id="viewer" style="display:none; flex:1; flex-direction:column;">
+          <div id="viewer-controls" style="padding:0.5rem; border-bottom:1px solid #ddd;">
+            <button id="back-button" class="mui-btn mui-btn--small">Back</button>
+            <button id="toggle-info" class="mui-btn mui-btn--small">Hide Info</button>
+            <button id="edit-file" class="mui-btn mui-btn--small" style="display:none;">Edit File</button>
+          </div>
+          <img id="viewer-placeholder" style="display:none; width:100%; flex:1; object-fit:cover;"/>
+          <iframe id="tool-frame" style="display:none;"></iframe>
+          <div id="tool-info">
+            <h3 id="tool-title"></h3>
+            <p id="tool-description"></p>
+            <small id="tool-keywords"></small>
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
+    </app-header-layout>
+  </app-drawer-layout>
   <script src="index.js" defer></script>
 
 </body>


### PR DESCRIPTION
## Summary
- integrate Polymer app-layout via CDN
- restructure `index.html` and `edit.html` to use `<app-drawer-layout>` with drawer and header

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847fd55cdf0832ba09b1694ab849a1c