### PR TITLE
Add static dashboard layout

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard Layout</title>
+  <style>
+    :root {
+      --bg: #fff;
+      --text: #000;
+      --header-bg: #1976d2;
+      --sidebar-bg: #f5f5f5;
+    }
+    body.dark {
+      --bg: #121212;
+      --text: #fff;
+      --header-bg: #333;
+      --sidebar-bg: #1e1e1e;
+    }
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      background: var(--header-bg);
+      color: var(--text);
+      padding: 0 1rem;
+      height: 48px;
+    }
+    header h1 {
+      font-size: 1.1rem;
+      margin: 0 1rem;
+    }
+    header .actions {
+      margin-left: auto;
+    }
+    #container {
+      flex: 1;
+      display: flex;
+      min-height: 0;
+    }
+    #sidebar {
+      width: 220px;
+      background: var(--sidebar-bg);
+      overflow-y: auto;
+      transition: width 0.2s;
+    }
+    #sidebar.collapsed {
+      width: 60px;
+    }
+    #sidebar ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    #sidebar li {
+      padding: 0.5rem 1rem;
+      display: flex;
+      align-items: center;
+    }
+    #sidebar li:hover {
+      background: rgba(0,0,0,0.05);
+    }
+    #sidebar li span.text {
+      margin-left: 0.5rem;
+    }
+    #sidebar.collapsed li span.text {
+      display: none;
+    }
+    #content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1rem;
+    }
+  </style>
+</head>
+<body class="light">
+  <header>
+    <button id="toggle-sidebar">☰</button>
+    <h1>Toolpad Dashboard</h1>
+    <div class="actions">
+      <button id="theme-toggle">Toggle theme</button>
+    </div>
+  </header>
+  <div id="container">
+    <nav id="sidebar">
+      <ul>
+        <li><span class="icon">🏠</span><span class="text">Dashboard</span></li>
+        <li><span class="icon">🛒</span><span class="text">Orders</span></li>
+        <li><span class="icon">📈</span><span class="text">Reports</span></li>
+        <li><span class="icon">🔗</span><span class="text">Integrations</span></li>
+      </ul>
+    </nav>
+    <main id="content">
+      <h2>Dashboard Content</h2>
+      <p>This is a barebones dashboard layout similar to the MUI Toolpad examples but implemented without React.</p>
+    </main>
+  </div>
+  <script>
+    const toggleBtn = document.getElementById('toggle-sidebar');
+    const sidebar = document.getElementById('sidebar');
+    const themeBtn = document.getElementById('theme-toggle');
+    themeBtn.addEventListener('click', () => {
+      document.body.classList.toggle('dark');
+    });
+    toggleBtn.addEventListener('click', () => {
+      sidebar.classList.toggle('collapsed');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dashboard layout HTML using vanilla JS for theme switching and sidebar collapse

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847fde73f40832b8a8a69c8ff4e9694