### PR TITLE
Improve screenshot capture and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,20 +67,30 @@
     }
     .card-frame {
       width: 100%;
-      height: 220px;
+      max-width: 450px;
+      max-height: 220px;
+      aspect-ratio: 450 / 220;
       border: 0;
       margin-bottom: 0.5rem;
       object-fit: cover;
+      object-position: center top;
     }
     #tool-frame {
       flex: 1;
-      border: 0;
       width: 100%;
+      max-width: 450px;
+      max-height: 220px;
+      aspect-ratio: 450 / 220;
+      border: 0;
     }
     #viewer-placeholder {
       flex: 1;
       width: 100%;
+      max-width: 450px;
+      max-height: 220px;
+      aspect-ratio: 450 / 220;
       object-fit: cover;
+      object-position: center top;
     }
     #tool-info {
       padding: 1rem;
@@ -155,7 +165,7 @@
         <button id="toggle-info" class="mui-btn mui-btn--small" aria-label="Toggle info"><span class="material-icons" aria-hidden="true">info</span></button>
         <button id="edit-file" class="mui-btn mui-btn--small" style="display:none;" aria-label="Edit"><span class="material-icons" aria-hidden="true">edit</span></button>
       </div>
-      <img id="viewer-placeholder" style="display:none; width:100%; flex:1; object-fit:cover;"/>
+      <img id="viewer-placeholder" style="display:none; flex:1;"/>
       <iframe id="tool-frame" style="display:none;"></iframe>
       <div id="tool-info">
         <button id="close-info" class="mui-btn mui-btn--flat mui-btn--small" aria-label="Close info"><span class="material-icons" aria-hidden="true">close</span></button>

--- a/index.js
+++ b/index.js
@@ -18,8 +18,15 @@ async function saveScreenshot(file, data) {
 async function captureScreenshot(iframe) {
   try {
     const doc = iframe.contentWindow.document;
-    const canvas = await html2canvas(doc.body);
-    return canvas.toDataURL('image/png');
+    // wait for fonts/styles to fully load to avoid jank
+    await new Promise(r => setTimeout(r, 5000));
+    const canvas = await html2canvas(doc.body, {
+      width: 450,
+      height: 220,
+      windowWidth: 450,
+      windowHeight: 220
+    });
+    return canvas.toDataURL('image/jpeg', 0.8);
   } catch (err) {
     console.warn('Unable to capture screenshot for', iframe.src, err);
     return null;


### PR DESCRIPTION
## Summary
- wait 5s and capture screenshots at 450x220 JPEG
- constrain iframe and image previews to 450x220 with aspect ratio

## Testing
- `npm run generate` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68480677b560832b8bf6aa46849f3f69