### PR TITLE
Fix new file loading and popups

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -14,6 +14,18 @@
     #main { flex:1; display:flex; flex-direction:column; padding:1rem; }
     #file-content { height:100%; }
     .CodeMirror { height:100%; }
+    #popup {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      background: rgba(0,0,0,0.85);
+      color: #fff;
+      padding: 0.75rem 1rem;
+      border-radius: 4px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+      display: none;
+      z-index: 1000;
+    }
   </style>
 </head>
 <body>
@@ -44,6 +56,7 @@
       </div>
     </div>
   </div>
+  <div id="popup"></div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/mode/xml/xml.min.js"></script>


### PR DESCRIPTION
## Summary
- avoid alert errors by reusing styled popup element
- allow `apiRequest` callers to permit 404 responses
- show empty editor when creating a new file

## Testing
- `npm run generate` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68493ee5fa20832b9f1fa6477e9b2d4a