### PR TITLE
Improve Poster Creator UI and add quick styling controls

### DIFF
--- a/tools/Poster Creator.html
+++ b/tools/Poster Creator.html
@@ -25,6 +25,7 @@
       body {
         font-family: "Roboto", sans-serif;
         overflow: hidden;
+        background: radial-gradient(circle at 20% 20%, #f8fafc 0%, #e0e7ff 45%, #e2e8f0 100%);
       }
       #loading-overlay {
         position: fixed;
@@ -49,6 +50,58 @@
       #poster-canvas {
         cursor: default;
       }
+      .panel-card {
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+      }
+      .control-summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.75rem 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        color: #1f2937;
+      }
+      summary.control-summary::-webkit-details-marker {
+        display: none;
+      }
+      details[open] > summary.control-summary svg {
+        transform: rotate(180deg);
+      }
+      details.control-section {
+        border-radius: 0.75rem;
+        border: 1px solid #e2e8f0;
+        background-color: #f8fafc;
+        transition: border-color 0.2s ease;
+      }
+      details.control-section[open] {
+        border-color: #6366f1;
+      }
+      .control-content {
+        padding: 0 1rem 1rem;
+      }
+      .color-preview {
+        height: 2.25rem;
+        min-width: 3rem;
+        border-radius: 0.5rem;
+        border: 1px solid #e2e8f0;
+        transition: transform 0.2s ease;
+      }
+      .color-preview:hover {
+        transform: translateY(-1px);
+      }
+      .swatch-button {
+        width: 2rem;
+        height: 2rem;
+        border-radius: 9999px;
+        border: 2px solid rgba(15, 23, 42, 0.1);
+        transition: transform 0.2s ease, border-color 0.2s ease;
+      }
+      .swatch-button:hover,
+      .swatch-button:focus {
+        transform: scale(1.05);
+        border-color: #6366f1;
+      }
       .btn-action {
         display: flex;
         align-items: center;
@@ -59,6 +112,8 @@
         border: 1px solid #d1d5db;
         border-radius: 0.375rem;
         background-color: white;
+        font-weight: 600;
+        color: #1f2937;
         transition: background-color 0.2s;
       }
       .btn-action:hover {
@@ -123,7 +178,7 @@
       }
     </style>
   </head>
-  <body class="bg-gray-100 flex flex-col lg:flex-row h-screen">
+  <body class="flex flex-col lg:flex-row h-screen">
     <div id="loading-overlay">
       <div class="text-center">
         <svg
@@ -153,11 +208,14 @@
     <!-- Controls Panel -->
     <div
       id="controls-panel"
-      class="w-full lg:w-80 xl:w-96 bg-white shadow-lg flex flex-col flex-shrink-0 transition-all duration-300"
+      class="w-full lg:w-80 xl:w-96 bg-white panel-card lg:rounded-r-3xl flex flex-col flex-shrink-0 transition-all duration-300"
     >
-      <div class="p-4 border-b flex justify-between items-center flex-shrink-0">
-        <h1 class="text-xl font-bold text-gray-800">Quick Block Text Poster</h1>
-        <button id="toggle-controls" class="lg:hidden p-2 rounded-md hover:bg-gray-200">
+      <div class="p-5 pb-3 border-b border-slate-200 flex justify-between items-center flex-shrink-0">
+        <div>
+          <p class="text-xs uppercase tracking-[0.2em] text-indigo-500 font-semibold">Poster Lab</p>
+          <h1 class="text-2xl font-extrabold text-slate-800">Quick Block Text Poster</h1>
+        </div>
+        <button id="toggle-controls" class="lg:hidden p-2 rounded-md hover:bg-slate-100">
           <svg id="menu-icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               stroke-linecap="round"
@@ -181,71 +239,102 @@
           </svg>
         </button>
       </div>
-      <div id="controls-content" class="overflow-y-auto p-4">
-        <div class="mb-4 text-sm text-gray-600 bg-gray-100 p-3 rounded-md">
-          <p>
-            <strong>Hint:</strong> New text auto-fits. Select to drag or resize. Hold
+      <div id="controls-content" class="overflow-y-auto p-5 space-y-6">
+        <div class="text-sm text-slate-600 bg-indigo-50/60 border border-indigo-100 p-4 rounded-xl">
+          <p class="font-medium text-indigo-900">Pro tip</p>
+          <p class="mt-1 leading-relaxed">
+            New lines auto-fit inside the canvas. Drag or resize blocks directly in the preview, and hold
             <kbd
-              class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-200 border border-gray-300 rounded-md"
+              class="px-2 py-1.5 text-xs font-semibold text-slate-800 bg-white border border-slate-200 rounded-md shadow-sm"
               >Shift</kbd
             >
-            to multi-select.
+            to select more than one line at a time. Press
+            <kbd
+              class="px-2 py-1.5 text-xs font-semibold text-slate-800 bg-white border border-slate-200 rounded-md shadow-sm"
+              >Ctrl</kbd
+            >
+            + click to open the rich editor.
           </p>
         </div>
         <div class="mb-4">
           <label for="text-input" class="block text-sm font-medium text-gray-700 mb-1"
             >Text (New line for each line)</label
           >
-          <textarea id="text-input" rows="6" class="w-full p-2 border border-gray-300 rounded-md">
-RESIZE ME
+          <textarea
+            id="text-input"
+            rows="6"
+            class="w-full p-3 border border-slate-200 rounded-xl focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+          >RESIZE ME
 *DRAG ME*
-HAVE FUN
-</textarea
-          >
+HAVE FUN</textarea>
         </div>
-        <div class="mb-4">
+        <div class="mb-6">
           <label for="margin-input" class="block text-sm font-medium text-gray-700 mb-1"
-            >Initial Margin (px)</label
+            >Initial Margin</label
           >
-          <input
-            type="number"
-            id="margin-input"
-            value="30"
-            class="w-full p-2 border border-gray-300 rounded-md"
-          />
+          <div class="flex items-center justify-between text-xs text-slate-500 mb-3">
+            <span>Keep text comfortably away from the edges.</span>
+            <span id="margin-display" class="px-2 py-0.5 rounded-full bg-slate-100 text-slate-700 font-semibold">30px</span>
+          </div>
+          <div class="space-y-3">
+            <input
+              type="range"
+              id="margin-range"
+              min="0"
+              max="200"
+              value="30"
+              class="w-full accent-indigo-500"
+            />
+            <input
+              type="number"
+              id="margin-input"
+              value="30"
+              class="w-full p-2 border border-slate-200 rounded-xl focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+            />
+          </div>
         </div>
-        <div class="p-4 border rounded-md mb-4 bg-gray-50">
-          <h2 class="text-lg font-semibold mb-2 text-gray-700">Actions</h2>
-          <div class="space-y-2">
-            <button id="download-btn" class="btn-action"><span>Download JPEG</span></button>
-            <button id="copy-btn" class="btn-action">
+        <div class="p-4 border border-slate-200 rounded-2xl mb-4 bg-slate-50">
+          <h2 class="text-lg font-semibold mb-3 text-slate-700">Quick Actions</h2>
+          <div class="grid grid-cols-2 gap-3">
+            <button id="download-btn" class="btn-action bg-white shadow-sm hover:shadow-md">
+              <span>Download JPEG</span>
+            </button>
+            <button id="copy-btn" class="btn-action bg-white shadow-sm hover:shadow-md">
               <span id="copy-btn-text">Copy Styles</span>
             </button>
-            <button id="undo-btn" class="btn-action"><span>Undo</span></button>
-            <button id="redo-btn" class="btn-action"><span>Redo</span></button>
+            <button id="undo-btn" class="btn-action bg-white shadow-sm hover:shadow-md"><span>Undo</span></button>
+            <button id="redo-btn" class="btn-action bg-white shadow-sm hover:shadow-md"><span>Redo</span></button>
           </div>
         </div>
         <div class="mb-4">
           <label for="canvas-size" class="block text-sm font-medium text-gray-700 mb-1"
             >Canvas Size</label
           >
-          <select id="canvas-size" class="w-full p-2 border border-gray-300 rounded-md">
+          <select
+            id="canvas-size"
+            class="w-full p-2 border border-slate-200 rounded-xl focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+          >
             <option value="tall">Tall (9:16)</option>
             <option value="wide">Wide (16:9)</option>
             <option value="square">Square (1:1)</option>
           </select>
         </div>
-        <div class="mb-4">
+        <div class="mb-6">
           <label for="bg-color" class="block text-sm font-medium text-gray-700 mb-1"
             >Background Color</label
           >
-          <input
-            type="text"
-            id="bg-color"
-            value="rgba(0,0,139,1)"
-            class="w-full p-1 border border-gray-300 rounded-md mb-2"
-            placeholder="rgba(r,g,b,a)"
-          />
+          <p class="text-xs text-slate-500">Use a swatch or enter an RGBA/Hex value for full control.</p>
+          <div class="mt-3 flex flex-wrap gap-2" id="bg-color-swatches"></div>
+          <div class="mt-3 flex items-center gap-3">
+            <input
+              type="text"
+              id="bg-color"
+              value="rgba(0,0,139,1)"
+              class="flex-1 p-2 border border-slate-200 rounded-xl focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+              placeholder="rgba(r,g,b,a)"
+            />
+            <div id="bg-color-preview" class="flex-1 color-preview"></div>
+          </div>
         </div>
         <div class="mb-4">
           <label for="bg-image" class="block text-sm font-medium text-gray-700 mb-1"
@@ -253,141 +342,148 @@ HAVE FUN
           >
           <input type="file" id="bg-image" accept="image/*" class="w-full" />
         </div>
-        <div class="p-4 border rounded-md mb-4 bg-gray-50">
-          <h2 class="text-lg font-semibold mb-2 text-gray-700">Primary Font</h2>
-          <select
-            id="primary-font"
-            class="w-full p-2 border border-gray-300 rounded-md mb-2"
-          ></select>
-          <input
-            type="text"
-            id="primary-color"
-            value="rgba(255,255,255,1)"
-            class="w-full p-1 border border-gray-300 rounded-md mb-2"
-            placeholder="rgba(r,g,b,a)"
-          />
-          <div class="flex flex-wrap items-center gap-4">
-            <label class="flex items-center"
-              ><input type="checkbox" id="primary-bold" class="rounded text-indigo-600" /><span
-                class="ml-2 text-sm"
-                >Bold</span
-              ></label
-            >
-            <label class="flex items-center"
-              ><input type="checkbox" id="primary-italic" class="rounded text-indigo-600" /><span
-                class="ml-2 text-sm"
-                >Italic</span
-              ></label
-            >
-            <label class="flex items-center"
-              ><input type="checkbox" id="primary-strike" class="rounded text-indigo-600" /><span
-                class="ml-2 text-sm"
-                >Strike</span
-              ></label
-            >
+        <details class="control-section" open>
+          <summary class="control-summary">
+            <span>Primary Font</span>
+            <svg class="w-4 h-4 text-slate-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </summary>
+          <div class="control-content space-y-3">
+            <select
+              id="primary-font"
+              class="w-full p-2 border border-slate-200 rounded-xl focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+            ></select>
+            <div class="flex items-center gap-3">
+              <input
+                type="text"
+                id="primary-color"
+                value="rgba(255,255,255,1)"
+                class="flex-1 p-2 border border-slate-200 rounded-xl focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+                placeholder="rgba(r,g,b,a)"
+              />
+              <div id="primary-color-preview" class="flex-1 color-preview"></div>
+            </div>
+            <div class="flex flex-wrap items-center gap-4">
+              <label class="flex items-center text-sm text-slate-600"
+                ><input type="checkbox" id="primary-bold" class="rounded text-indigo-600 mr-2" />Bold</label
+              >
+              <label class="flex items-center text-sm text-slate-600"
+                ><input type="checkbox" id="primary-italic" class="rounded text-indigo-600 mr-2" />Italic</label
+              >
+              <label class="flex items-center text-sm text-slate-600"
+                ><input type="checkbox" id="primary-strike" class="rounded text-indigo-600 mr-2" />Strike</label
+              >
+            </div>
+            <div class="grid grid-cols-3 gap-2">
+              <input
+                type="number"
+                id="primary-shadow-x"
+                value="2"
+                class="p-2 border border-slate-200 rounded-lg"
+                placeholder="X"
+              />
+              <input
+                type="number"
+                id="primary-shadow-y"
+                value="2"
+                class="p-2 border border-slate-200 rounded-lg"
+                placeholder="Y"
+              />
+              <input
+                type="number"
+                id="primary-shadow-blur"
+                value="4"
+                class="p-2 border border-slate-200 rounded-lg"
+                placeholder="Blur"
+              />
+              <input
+                type="text"
+                id="primary-shadow-color"
+                value="rgba(0,0,0,0.5)"
+                class="col-span-3 p-2 border border-slate-200 rounded-lg"
+                placeholder="rgba(r,g,b,a)"
+              />
+            </div>
+            <div class="flex flex-wrap gap-2" id="primary-color-swatches"></div>
           </div>
-          <div class="grid grid-cols-3 gap-2 mt-2">
-            <input
-              type="number"
-              id="primary-shadow-x"
-              value="2"
-              class="p-1 border border-gray-300 rounded-md"
-              placeholder="X"
-            />
-            <input
-              type="number"
-              id="primary-shadow-y"
-              value="2"
-              class="p-1 border border-gray-300 rounded-md"
-              placeholder="Y"
-            />
-            <input
-              type="number"
-              id="primary-shadow-blur"
-              value="4"
-              class="p-1 border border-gray-300 rounded-md"
-              placeholder="Blur"
-            />
-            <input
-              type="text"
-              id="primary-shadow-color"
-              value="rgba(0,0,0,0.5)"
-              class="col-span-3 p-1 border border-gray-300 rounded-md"
-              placeholder="rgba(r,g,b,a)"
-            />
+        </details>
+        <details class="control-section" open>
+          <summary class="control-summary">
+            <span>Call-to-Action Font</span>
+            <svg class="w-4 h-4 text-slate-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </summary>
+          <div class="control-content space-y-3">
+            <select
+              id="secondary-font"
+              class="w-full p-2 border border-slate-200 rounded-xl focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+            ></select>
+            <div class="flex items-center gap-3">
+              <input
+                type="text"
+                id="secondary-color"
+                value="rgba(173,216,230,1)"
+                class="flex-1 p-2 border border-slate-200 rounded-xl focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+                placeholder="rgba(r,g,b,a)"
+              />
+              <div id="secondary-color-preview" class="flex-1 color-preview"></div>
+            </div>
+            <div class="flex flex-wrap items-center gap-4">
+              <label class="flex items-center text-sm text-slate-600"
+                ><input type="checkbox" id="secondary-bold" class="rounded text-indigo-600 mr-2" />Bold</label
+              >
+              <label class="flex items-center text-sm text-slate-600"
+                ><input type="checkbox" id="secondary-italic" class="rounded text-indigo-600 mr-2" />Italic</label
+              >
+              <label class="flex items-center text-sm text-slate-600"
+                ><input type="checkbox" id="secondary-strike" class="rounded text-indigo-600 mr-2" />Strike</label
+              >
+            </div>
+            <div class="grid grid-cols-3 gap-2">
+              <input
+                type="number"
+                id="secondary-shadow-x"
+                value="2"
+                class="p-2 border border-slate-200 rounded-lg"
+                placeholder="X"
+              />
+              <input
+                type="number"
+                id="secondary-shadow-y"
+                value="2"
+                class="p-2 border border-slate-200 rounded-lg"
+                placeholder="Y"
+              />
+              <input
+                type="number"
+                id="secondary-shadow-blur"
+                value="4"
+                class="p-2 border border-slate-200 rounded-lg"
+                placeholder="Blur"
+              />
+              <input
+                type="text"
+                id="secondary-shadow-color"
+                value="rgba(0,0,0,0.5)"
+                class="col-span-3 p-2 border border-slate-200 rounded-lg"
+                placeholder="rgba(r,g,b,a)"
+              />
+            </div>
+            <div class="flex flex-wrap gap-2" id="secondary-color-swatches"></div>
           </div>
-        </div>
-        <div class="p-4 border rounded-md bg-gray-50">
-          <h2 class="text-lg font-semibold mb-2 text-gray-700">Call-to-Action Font (*)</h2>
-          <select
-            id="secondary-font"
-            class="w-full p-2 border border-gray-300 rounded-md mb-2"
-          ></select>
-          <input
-            type="text"
-            id="secondary-color"
-            value="rgba(173,216,230,1)"
-            class="w-full p-1 border border-gray-300 rounded-md mb-2"
-            placeholder="rgba(r,g,b,a)"
-          />
-          <div class="flex flex-wrap items-center gap-4">
-            <label class="flex items-center"
-              ><input type="checkbox" id="secondary-bold" class="rounded text-indigo-600" /><span
-                class="ml-2 text-sm"
-                >Bold</span
-              ></label
-            >
-            <label class="flex items-center"
-              ><input type="checkbox" id="secondary-italic" class="rounded text-indigo-600" /><span
-                class="ml-2 text-sm"
-                >Italic</span
-              ></label
-            >
-            <label class="flex items-center"
-              ><input type="checkbox" id="secondary-strike" class="rounded text-indigo-600" /><span
-                class="ml-2 text-sm"
-                >Strike</span
-              ></label
-            >
-          </div>
-          <div class="grid grid-cols-3 gap-2 mt-2">
-            <input
-              type="number"
-              id="secondary-shadow-x"
-              value="2"
-              class="p-1 border border-gray-300 rounded-md"
-              placeholder="X"
-            />
-            <input
-              type="number"
-              id="secondary-shadow-y"
-              value="2"
-              class="p-1 border border-gray-300 rounded-md"
-              placeholder="Y"
-            />
-            <input
-              type="number"
-              id="secondary-shadow-blur"
-              value="4"
-              class="p-1 border border-gray-300 rounded-md"
-              placeholder="Blur"
-            />
-            <input
-              type="text"
-              id="secondary-shadow-color"
-              value="rgba(0,0,0,0.5)"
-              class="col-span-3 p-1 border border-gray-300 rounded-md"
-              placeholder="rgba(r,g,b,a)"
-            />
-          </div>
-        </div>
+        </details>
       </div>
     </div>
     <div
       id="canvas-container"
-      class="flex-grow flex items-center justify-center p-4 bg-gray-200 relative min-h-0"
+      class="flex-grow flex items-center justify-center p-6 bg-gradient-to-br from-slate-100 via-white to-slate-200 relative min-h-0"
     >
-      <canvas id="poster-canvas" class="bg-white shadow-lg rounded-md"></canvas>
+      <canvas
+        id="poster-canvas"
+        class="bg-white shadow-2xl rounded-3xl border border-white/60"
+      ></canvas>
       <div
         id="item-editor"
         class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
@@ -505,6 +601,8 @@ HAVE FUN
           const canvasContainer = document.getElementById('canvas-container');
           const textInput = document.getElementById('text-input');
           const marginInput = document.getElementById('margin-input');
+          const marginRange = document.getElementById('margin-range');
+          const marginDisplay = document.getElementById('margin-display');
           const downloadBtn = document.getElementById('download-btn');
           const undoBtn = document.getElementById('undo-btn');
           const redoBtn = document.getElementById('redo-btn');
@@ -523,6 +621,17 @@ HAVE FUN
           };
           const editorReset = document.getElementById('editor-reset');
           const editorClose = document.getElementById('editor-close');
+
+          const colorPreviews = {
+              background: document.getElementById('bg-color-preview'),
+              primary: document.getElementById('primary-color-preview'),
+              secondary: document.getElementById('secondary-color-preview')
+          };
+          const colorSwatchContainers = {
+              background: document.getElementById('bg-color-swatches'),
+              primary: document.getElementById('primary-color-swatches'),
+              secondary: document.getElementById('secondary-color-swatches')
+          };
 
           const controls = {
               bgColor: document.getElementById('bg-color'),
@@ -552,6 +661,54 @@ HAVE FUN
               }
           };
 
+          function updateColorPreview(type) {
+              const preview = colorPreviews[type];
+              if (!preview) return;
+              let value = '';
+              if (type === 'background') value = controls.bgColor.value;
+              if (type === 'primary') value = controls.primary.color.value;
+              if (type === 'secondary') value = controls.secondary.color.value;
+              preview.style.background = value || 'transparent';
+          }
+
+          function updateMarginDisplay() {
+              if (!marginDisplay) return;
+              marginDisplay.textContent = `${marginInput.value}px`;
+          }
+
+          function renderColorSwatches(type) {
+              const container = colorSwatchContainers[type];
+              if (!container) return;
+              container.innerHTML = '';
+              const palette = palettePresets[type];
+              palette.forEach(color => {
+                  const button = document.createElement('button');
+                  button.type = 'button';
+                  button.className = 'swatch-button focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-400';
+                  button.style.background = color;
+                  button.setAttribute('aria-label', `Apply ${color} ${type} color`);
+                  button.title = color;
+                  button.addEventListener('click', () => {
+                      if (type === 'background') {
+                          controls.bgColor.value = color;
+                          controls.bgColor.dispatchEvent(new Event('input', { bubbles: true }));
+                      } else if (type === 'primary') {
+                          controls.primary.color.value = color;
+                          controls.primary.color.dispatchEvent(new Event('input', { bubbles: true }));
+                      } else if (type === 'secondary') {
+                          controls.secondary.color.value = color;
+                          controls.secondary.color.dispatchEvent(new Event('input', { bubbles: true }));
+                      }
+                  });
+                  container.appendChild(button);
+              });
+          }
+
+          function handleMarginChange() {
+              updateMarginDisplay();
+              syncTextItems();
+          }
+
           let textItems = [];
           let currentEditItem = null;
           let backgroundImage = null;
@@ -560,6 +717,11 @@ HAVE FUN
           const redoStack = [];
           const RESIZE_HANDLE_SIZE = 20;
           const sizes = { tall: { width: 1080, height: 1920 }, wide: { width: 1920, height: 1080 }, square: { width: 1080, height: 1080 } };
+          const palettePresets = {
+              background: ['rgba(10,25,47,1)', 'rgba(15,118,110,1)', 'rgba(30,64,175,1)', 'rgba(2,6,23,1)', 'rgba(244,244,245,1)', 'rgba(249,115,22,1)'],
+              primary: ['rgba(255,255,255,1)', 'rgba(15,23,42,1)', 'rgba(254,243,199,1)', 'rgba(226,232,240,1)', 'rgba(248,250,252,1)', 'rgba(252,211,77,1)'],
+              secondary: ['rgba(59,130,246,1)', 'rgba(244,114,182,1)', 'rgba(16,185,129,1)', 'rgba(239,68,68,1)', 'rgba(14,165,233,1)', 'rgba(167,139,250,1)']
+          };
 
           function cloneState() {
               return {
@@ -610,6 +772,7 @@ HAVE FUN
               if (state.ui) {
                   textInput.value = state.ui.text;
                   marginInput.value = state.ui.margin;
+                  if (marginRange) marginRange.value = state.ui.margin;
                   controls.bgColor.value = state.ui.bgColor;
                   const p = state.ui.primary;
                   controls.primary.font.value = p.font;
@@ -632,6 +795,10 @@ HAVE FUN
                   controls.secondary.shadowBlur.value = s.shadowBlur;
                   controls.secondary.shadowColor.value = s.shadowColor;
               }
+              updateColorPreview('background');
+              updateColorPreview('primary');
+              updateColorPreview('secondary');
+              updateMarginDisplay();
               draw();
           }
 
@@ -729,6 +896,8 @@ HAVE FUN
           }
 
           function syncTextItems() {
+              if (marginRange) marginRange.value = marginInput.value;
+              updateMarginDisplay();
               const lines = textInput.value.split('\n');
               const newTextItems = [];
               let totalHeight = 0;
@@ -1021,6 +1190,8 @@ HAVE FUN
                   });
                   draw();
               }
+              updateColorPreview('primary');
+              updateColorPreview('secondary');
           }
 
           function openItemEditor(item) {
@@ -1119,10 +1290,27 @@ HAVE FUN
 
           function init() {
               populateFontSelectors();
+              ['background', 'primary', 'secondary'].forEach(renderColorSwatches);
+              updateColorPreview('background');
+              updateColorPreview('primary');
+              updateColorPreview('secondary');
               resizeCanvas();
               textInput.addEventListener('input', syncTextItems);
-              marginInput.addEventListener('change', syncTextItems);
-              controls.bgColor.addEventListener('input', draw);
+              marginInput.addEventListener('input', () => {
+                  if (marginRange) marginRange.value = marginInput.value;
+                  handleMarginChange();
+              });
+              if (marginRange) {
+                  marginRange.addEventListener('input', () => {
+                      marginInput.value = marginRange.value;
+                      handleMarginChange();
+                  });
+              }
+              controls.bgColor.addEventListener('input', () => {
+                  updateColorPreview('background');
+                  draw();
+                  saveState();
+              });
               controls.bgImage.addEventListener('change', handleImageUpload);
               downloadBtn.addEventListener('click', downloadImage);
               undoBtn.addEventListener('click', undo);


### PR DESCRIPTION
## Summary
- refresh the poster creator layout with a gradient shell, upgraded typography, and collapsible control sections
- add quick actions, a synchronized margin slider, and live color previews plus swatch palettes for backgrounds and fonts
- wire the new UI widgets into the editor logic to keep previews, undo/redo state, and margin displays updated

## Testing
- Manual UI check on Poster Creator page

------
https://chatgpt.com/codex/tasks/task_e_68dd8cc814b4832b9bd35dfb1064367b